### PR TITLE
Fix missing methods in interfaces

### DIFF
--- a/oauth2/authorization_code/authorization_code.go
+++ b/oauth2/authorization_code/authorization_code.go
@@ -22,8 +22,6 @@ const (
 type (
 	TokenType string
 
-	Option func(*AuthorizationCodeFlow)
-
 	ISessionHooks interface {
 		GetState() (string, error)
 		SetState(state string) error
@@ -33,12 +31,23 @@ type (
 		GetPostAuthRedirect() (string, error)
 	}
 
-	IDeviceAuthorizationFlow interface {
-	}
-
 	IAuthorizationCodeFlow interface {
 		GetAuthURL() string
 		ExchangeCode(ctx context.Context, authorizationCode string, receivedState string) error
+		GetHttpClient(ctx context.Context, tokenSource oauth2.TokenSource) *http.Client
+		GetToken() (*jwt.Token, error)
+		IsAuthenticated() bool
+		Logout() error
+		AuthorizationCodeReceivedHandler(w http.ResponseWriter, r *http.Request)
+	}
+
+	IDeviceAuthorizationFlow interface {
+		StartDeviceAuth(ctx context.Context) (*oauth2.DeviceAuthResponse, error)
+		ExchangeDeviceAccessToken(ctx context.Context, da *oauth2.DeviceAuthResponse, opts ...oauth2.AuthCodeOption) error
+		GetHttpClient(ctx context.Context, tokenSource oauth2.TokenSource) *http.Client
+		GetToken() (*jwt.Token, error)
+		IsAuthenticated() bool
+		Logout() error
 	}
 
 	// AuthorizationCodeFlow represents the authorization code flow.
@@ -109,6 +118,51 @@ func NewAuthorizationCodeFlow(baseURL string, clientID string, clientSecret stri
 // Creates a new AuthorizationCodeFlow with the given baseURL, clientID, clientSecret and options to authenticate backend applications.
 func NewDeviceAuthorizationFlow(baseURL string, options ...Option) (IDeviceAuthorizationFlow, error) {
 	return newAuthorizationCodeFlow(baseURL, "", "", "", options...)
+}
+
+// StartDeviceAuth retrieves the device authorization response.
+// It returns the device authorization response or an error if the request fails.
+// This is used for the device authorization flow.
+func (flow *AuthorizationCodeFlow) StartDeviceAuth(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
+	return flow.config.DeviceAuth(ctx)
+}
+
+// Returns the URL to redirect the user to start authentication pipeline.
+func (flow *AuthorizationCodeFlow) GetAuthURL() string {
+
+	state := flow.stateGenerator(flow)
+	url, _ := url.Parse(flow.config.AuthCodeURL(state))
+	query := url.Query()
+	for k, v := range flow.authURLOptions {
+		if query.Get(k) == "" {
+			query[k] = v
+		}
+	}
+	url.RawQuery = query.Encode()
+	return url.String()
+}
+
+// AuthorizationCodeReceivedHandler handles the callback from the authorization server.
+func (flow *AuthorizationCodeFlow) AuthorizationCodeReceivedHandler(w http.ResponseWriter, r *http.Request) {
+	receivedState := r.URL.Query().Get("state")
+	if flow.stateVerifier(flow, receivedState) {
+		token, err := flow.config.Exchange(r.Context(), receivedState)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		parsedToken, err := jwt.ParseOAuth2Token(token, flow.tokenOptions...)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if parsedToken.IsValid() {
+			stringToken, err := parsedToken.AsString()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			flow.sessionHooks.SetToken(RawToken, stringToken)
+		}
+	}
 }
 
 func newAuthorizationCodeFlow(baseURL string, clientID string, clientSecret string, callbackURL string,
@@ -202,6 +256,11 @@ func (flow *AuthorizationCodeFlow) ExchangeDeviceAccessToken(ctx context.Context
 	return err
 }
 
+// Returns the client to make requests to the backend, will refreesh token if offline is requested.
+func (flow *AuthorizationCodeFlow) GetHttpClient(ctx context.Context, tokenSource oauth2.TokenSource) *http.Client {
+	return oauth2.NewClient(ctx, tokenSource)
+}
+
 func (flow *AuthorizationCodeFlow) parseFromSessionStorage() (*jwt.Token, error) {
 	rawToken, err := flow.sessionHooks.GetToken(RawToken)
 	if err != nil {
@@ -237,9 +296,4 @@ func (flow *AuthorizationCodeFlow) validateAndStoreToken(token *oauth2.Token) (*
 		flow.sessionHooks.SetToken(RefreshToken, refreshToken)
 	}
 	return jwtToken, nil
-}
-
-// Returns the client to make requests to the backend, will refreesh token if offline is requested.
-func (flow *AuthorizationCodeFlow) GetClient(ctx context.Context, tokenSource oauth2.TokenSource) *http.Client {
-	return oauth2.NewClient(ctx, tokenSource)
 }

--- a/oauth2/authorization_code/options.go
+++ b/oauth2/authorization_code/options.go
@@ -1,17 +1,17 @@
 package authorization_code
 
 import (
-	"context"
-	"net/http"
-	"net/url"
 	"slices"
 
 	"github.com/kinde-oss/kinde-go/jwt"
-	"golang.org/x/oauth2"
+)
+
+type (
+	Option func(*AuthorizationCodeFlow)
 )
 
 // Adds an arbitrary parameter to the list of parameters to request.
-func WithAuthParameter(name, value string) func(*AuthorizationCodeFlow) {
+func WithAuthParameter(name, value string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		if val, ok := s.authURLOptions[name]; ok {
 			if !slices.Contains(val, value) {
@@ -25,70 +25,70 @@ func WithAuthParameter(name, value string) func(*AuthorizationCodeFlow) {
 }
 
 // Adds an audience to the list of audiences to request.
-func WithAudience(audience string) func(*AuthorizationCodeFlow) {
+func WithAudience(audience string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		WithAuthParameter("audience", audience)(s)
 	}
 }
 
 // Adds an audience to the list of audiences to request.
-func WithPrompt(prompt string) func(*AuthorizationCodeFlow) {
+func WithPrompt(prompt string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		WithAuthParameter("prompt", prompt)(s)
 	}
 }
 
 // Adds the offline scope to the list of scopes to request.
-func WithOffline() func(*AuthorizationCodeFlow) {
+func WithOffline() Option {
 	return func(s *AuthorizationCodeFlow) {
 		WithAdditionalScope("offline")(s)
 	}
 }
 
 // Adds the offline scope to the list of scopes to request.
-func WithCustomStateGenerator(stateFunc func(*AuthorizationCodeFlow) string) func(*AuthorizationCodeFlow) {
+func WithCustomStateGenerator(stateFunc func(*AuthorizationCodeFlow) string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.stateGenerator = stateFunc
 	}
 }
 
 // Integrates with the session management
-func WithSessionHooks(sessionHooks ISessionHooks) func(*AuthorizationCodeFlow) {
+func WithSessionHooks(sessionHooks ISessionHooks) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.sessionHooks = sessionHooks
 	}
 }
 
 // Integrates with the session management
-func WithClientID(clientID string) func(*AuthorizationCodeFlow) {
+func WithClientID(clientID string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.config.ClientID = clientID
 	}
 }
 
 // Integrates with the session management
-func WithClientSecret(clientSecret string) func(*AuthorizationCodeFlow) {
+func WithClientSecret(clientSecret string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.config.ClientSecret = clientSecret
 	}
 }
 
 // Adds a scopes to the list of scopes to request, replaces value with the provided.
-func WithScopes(scopes ...string) func(*AuthorizationCodeFlow) {
+func WithScopes(scopes ...string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.config.Scopes = scopes
 	}
 }
 
 // Adds a scopes to the list of scopes to request, adds scope to existing list.
-func WithAdditionalScope(scope string) func(*AuthorizationCodeFlow) {
+func WithAdditionalScope(scope string) Option {
 	return func(s *AuthorizationCodeFlow) {
 		s.config.Scopes = append(s.config.Scopes, scope)
 	}
 }
 
 // Adds options to validate the token.
-func WithTokenValidation(isValidateJWKS bool, tokenOptions ...func(*jwt.Token)) func(*AuthorizationCodeFlow) {
+func WithTokenValidation(isValidateJWKS bool, tokenOptions ...func(*jwt.Token)) Option {
 	return func(s *AuthorizationCodeFlow) {
 
 		if isValidateJWKS {
@@ -97,48 +97,4 @@ func WithTokenValidation(isValidateJWKS bool, tokenOptions ...func(*jwt.Token)) 
 
 		s.tokenOptions = append(s.tokenOptions, tokenOptions...)
 	}
-}
-
-func (flow *AuthorizationCodeFlow) AuthorizationCodeReceived(w http.ResponseWriter, r *http.Request) {
-	receivedState := r.URL.Query().Get("state")
-	if flow.stateVerifier(flow, receivedState) {
-		token, err := flow.config.Exchange(r.Context(), receivedState)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		parsedToken, err := jwt.ParseOAuth2Token(token, flow.tokenOptions...)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if parsedToken.IsValid() {
-			stringToken, err := parsedToken.AsString()
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			flow.sessionHooks.SetToken(RawToken, stringToken)
-		}
-	}
-}
-
-// StartDeviceAuth retrieves the device authorization response.
-// It returns the device authorization response or an error if the request fails.
-// This is used for the device authorization flow.
-func (flow *AuthorizationCodeFlow) StartDeviceAuth(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
-	return flow.config.DeviceAuth(ctx)
-}
-
-// Returns the URL to redirect the user to start authentication pipeline.
-func (flow *AuthorizationCodeFlow) GetAuthURL() string {
-
-	state := flow.stateGenerator(flow)
-	url, _ := url.Parse(flow.config.AuthCodeURL(state))
-	query := url.Query()
-	for k, v := range flow.authURLOptions {
-		if query.Get(k) == "" {
-			query[k] = v
-		}
-	}
-	url.RawQuery = query.Encode()
-	return url.String()
 }

--- a/oauth2/client_credentials/client_credentials.go
+++ b/oauth2/client_credentials/client_credentials.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/kinde-oss/kinde-go/jwt"
 	"golang.org/x/oauth2"
@@ -17,8 +16,6 @@ type (
 		GetClient(ctx context.Context) *http.Client
 		GetToken(ctx context.Context) (*jwt.Token, error)
 	}
-
-	Option func(*ClientCredentialsFlow)
 
 	// ClientCredentialsFlow represents the client credentials flow.
 	ClientCredentialsFlow struct {
@@ -56,62 +53,6 @@ func NewClientCredentialsFlow(baseURL string, clientID string, clientSecret stri
 	client.tokenSource = client.config.TokenSource(context.Background())
 
 	return client, nil
-}
-
-// Adds an arbitrary parameter to the list of parameters to request.
-func WithAuthParameter(key, value string) func(*ClientCredentialsFlow) {
-	return func(s *ClientCredentialsFlow) {
-		if params, ok := s.config.EndpointParams[key]; ok {
-			s.config.EndpointParams[key] = append(params, value)
-		} else {
-			s.config.EndpointParams[key] = []string{value}
-		}
-	}
-}
-
-// Adds an arbitrary parameter to the list of parameters to request.
-func WithAudience(audience string) func(*ClientCredentialsFlow) {
-	return func(s *ClientCredentialsFlow) {
-		WithAuthParameter("audience", audience)(s)
-	}
-}
-
-// Adds Kinde management API audience to the list of audiences to request.
-func WithKindeManagementAPI(kindeDomain string) func(*ClientCredentialsFlow) {
-	return func(s *ClientCredentialsFlow) {
-
-		asURL, err := url.Parse(kindeDomain)
-		if err != nil {
-			return
-		}
-
-		host := asURL.Hostname()
-		if host == "" {
-			host = kindeDomain
-		}
-
-		host = strings.TrimSuffix(host, ".kinde.com")
-
-		managementApiAudience := fmt.Sprintf("https://%v.kinde.com/api", host)
-		WithAuthParameter("audience", managementApiAudience)(s)
-		WithAudience(managementApiAudience)(s)
-		WithTokenValidation(
-			true,
-			jwt.WillValidateAlgorythm(),
-		)(s)
-	}
-}
-
-// Adds options to validate the token.
-func WithTokenValidation(isValidateJWKS bool, tokenOptions ...func(*jwt.Token)) func(*ClientCredentialsFlow) {
-	return func(s *ClientCredentialsFlow) {
-
-		if isValidateJWKS {
-			s.tokenOptions = append(s.tokenOptions, jwt.WillValidateWithJWKSUrl(s.JWKS_URL))
-		}
-
-		s.tokenOptions = append(s.tokenOptions, tokenOptions...)
-	}
 }
 
 // Returns the http client to be used to make requests.

--- a/oauth2/client_credentials/options.go
+++ b/oauth2/client_credentials/options.go
@@ -1,0 +1,69 @@
+package client_credentials
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/kinde-oss/kinde-go/jwt"
+)
+
+type (
+	Option func(*ClientCredentialsFlow)
+)
+
+// Adds an arbitrary parameter to the list of parameters to request.
+func WithAuthParameter(key, value string) Option {
+	return func(s *ClientCredentialsFlow) {
+		if params, ok := s.config.EndpointParams[key]; ok {
+			s.config.EndpointParams[key] = append(params, value)
+		} else {
+			s.config.EndpointParams[key] = []string{value}
+		}
+	}
+}
+
+// Adds an arbitrary parameter to the list of parameters to request.
+func WithAudience(audience string) Option {
+	return func(s *ClientCredentialsFlow) {
+		WithAuthParameter("audience", audience)(s)
+	}
+}
+
+// Adds Kinde management API audience to the list of audiences to request.
+func WithKindeManagementAPI(kindeDomain string) Option {
+	return func(s *ClientCredentialsFlow) {
+
+		asURL, err := url.Parse(kindeDomain)
+		if err != nil {
+			return
+		}
+
+		host := asURL.Hostname()
+		if host == "" {
+			host = kindeDomain
+		}
+
+		host = strings.TrimSuffix(host, ".kinde.com")
+
+		managementApiAudience := fmt.Sprintf("https://%v.kinde.com/api", host)
+		WithAuthParameter("audience", managementApiAudience)(s)
+		WithAudience(managementApiAudience)(s)
+		WithTokenValidation(
+			true,
+			jwt.WillValidateAlgorythm(),
+		)(s)
+	}
+}
+
+// Adds options to validate the token.
+func WithTokenValidation(isValidateJWKS bool, tokenOptions ...func(*jwt.Token)) Option {
+	return func(s *ClientCredentialsFlow) {
+
+		if isValidateJWKS {
+			s.tokenOptions = append(s.tokenOptions, jwt.WillValidateWithJWKSUrl(s.JWKS_URL))
+		}
+
+		s.tokenOptions = append(s.tokenOptions, tokenOptions...)
+	}
+}


### PR DESCRIPTION
Add necessary methods to the `IAuthorizationCodeFlow` and `IDeviceAuthorizationFlow` interfaces, ensuring proper functionality for device authorization and token management. Clean up redundant code and improve overall structure.