### PR TITLE
Add GetClaims method to Token struct

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -142,3 +142,13 @@ func (j *Token) GetSubject() string {
 	subject, _ := j.processing.parsed.Claims.GetSubject()
 	return subject
 }
+
+func (j *Token) GetClaims() map[string]any {
+	if j.processing.parsed == nil {
+		return make(map[string]any)
+	}
+	if claims, ok := j.processing.parsed.Claims.(golangjwt.MapClaims); ok {
+		return claims
+	}
+	return make(map[string]any)
+}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"testing"
 
+	golangjwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,6 +35,37 @@ func TestTokenNeedsKeyFuncToWork(t *testing.T) {
 		)
 		assert.NotNil(t, err, "expecting error validating a token")
 		assert.False(t, parsedToken.IsValid(), "token should be not valid")
+	})
+
+}
+
+func TestToken_GetClaims(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty map when parsed is nil", func(t *testing.T) {
+		token := &Token{}
+		claims := token.GetClaims()
+		assert.NotNil(t, claims)
+		assert.Equal(t, 0, len(claims))
+	})
+
+	t.Run("returns claims when parsed is set and claims are MapClaims", func(t *testing.T) {
+		expectedClaims := map[string]any{
+			"sub": "test_subject",
+			"aud": "test_audience",
+		}
+		token := &Token{
+			processing: tokenProcessing{
+				parsed: &golangjwt.Token{
+					Claims: golangjwt.MapClaims{
+						"sub": "test_subject",
+						"aud": "test_audience",
+					},
+				},
+			},
+		}
+		claims := token.GetClaims()
+		assert.Equal(t, expectedClaims, claims)
 	})
 
 }


### PR DESCRIPTION
Introduce the GetClaims method to retrieve claims from the JWT token, along with tests to validate its behavior in different scenarios.