### PR TITLE
Kinde API to accept client credentials flow only

### DIFF
--- a/kinde/kinde.go
+++ b/kinde/kinde.go
@@ -3,7 +3,6 @@ package kinde
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/kinde-oss/kinde-go/kinde/management_api"
 	"github.com/kinde-oss/kinde-go/oauth2/client_credentials"
@@ -31,19 +30,7 @@ func (s *securitySource) KindeBearerAuth(ctx context.Context, operationName mana
 }
 
 // NewManagementAPI creates a new management API client using the provided Kinde tenant URL, client ID, and client secret.
-func NewManagementAPI(ctx context.Context, kindeTenantURL string, clientID string, clientSecret string, options ...client_credentials.Option) (*management_api.Client, error) {
-
-	kindeTenantURL = strings.ToLower(kindeTenantURL)
-	if kindeTenantURL == "" {
-		return nil, fmt.Errorf("kindeTenantDomain cannot be empty")
-	}
-
-	options = append(options, client_credentials.WithKindeManagementAPI(kindeTenantURL))
-
-	flow, err := client_credentials.NewClientCredentialsFlow(kindeTenantURL, clientID, clientSecret, options...)
-	if err != nil {
-		return nil, err
-	}
+func NewManagementAPI(ctx context.Context, kindeTenantURL string, flow client_credentials.IClientCredentialsFlow) (*management_api.Client, error) {
 
 	client, err := flow.GetClient(ctx)
 	managementApiClient, err := management_api.NewClient(kindeTenantURL, &securitySource{clientCredentials: flow}, management_api.WithClient(client))

--- a/kinde/kinde_test.go
+++ b/kinde/kinde_test.go
@@ -97,7 +97,15 @@ func TestManagementAPI(t *testing.T) {
 	kindeAPIUrl = fmt.Sprintf("%s/api", authorizationServer.URL)
 
 	ctx := context.Background()
-	kindeManagementAPI, err := NewManagementAPI(ctx, issuerURL, "b9da18c441b44d81bab3e8232de2e18d", "client_secret", client_credentials.WithSessionHooks(newTestSessionHooks()))
+	clientCredentialsFlow, err := client_credentials.NewClientCredentialsFlow(
+		issuerURL,
+		"b9da18c441b44d81bab3e8232de2e18d",
+		"client_secret",
+		client_credentials.WithSessionHooks(newTestSessionHooks()),
+		client_credentials.WithKindeManagementAPI(kindeAPIUrl),
+		client_credentials.WithTokenValidation(true),
+	)
+	kindeManagementAPI, err := NewManagementAPI(ctx, issuerURL, clientCredentialsFlow)
 	assert.NotNil(kindeManagementAPI, "management API client should not be nil")
 	assert.Nil(err, "error creating management API client")
 


### PR DESCRIPTION
Refactor the management API client creation to exclusively utilize the client credentials flow, removing support for other authentication methods.