### PR TITLE
Refactor token handling for chunked storage in cliSession

### DIFF
--- a/frameworks/cli/cliSession.go
+++ b/frameworks/cli/cliSession.go
@@ -15,19 +15,47 @@ const (
 
 type (
 	cliSession struct {
-		configFileName string
-		keyring        keyring.Keyring
+		keyring keyring.Keyring
 	}
 )
 
 // GetRawToken implements authorization_code.ISessionHooks.
 func (c *cliSession) GetRawToken() (*oauth2.Token, error) {
-	token, err := c.keyring.Get(fmt.Sprintf("%s_token", keyPrefix))
+	key := fmt.Sprintf("%s_token", keyPrefix)
+	countKey := fmt.Sprintf("%s_chunk_count", key)
+
+	// Try to get chunk count
+	countItem, err := c.keyring.Get(countKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get token: %w", err)
+		// fallback to single token (old format)
+		token, err := c.keyring.Get(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get token: %w", err)
+		}
+		var t oauth2.Token
+		if err := json.Unmarshal(token.Data, &t); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal token: %w", err)
+		}
+		return &t, nil
 	}
+
+	var chunks int
+	if _, err := fmt.Sscanf(string(countItem.Data), "%d", &chunks); err != nil {
+		return nil, fmt.Errorf("failed to parse chunk count: %w", err)
+	}
+
+	var tokenData []byte
+	for i := 0; i < chunks; i++ {
+		chunkKey := fmt.Sprintf("%s_chunk_%d", key, i)
+		chunkItem, err := c.keyring.Get(chunkKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get token chunk %d: %w", i, err)
+		}
+		tokenData = append(tokenData, chunkItem.Data...)
+	}
+
 	var t oauth2.Token
-	if err := json.Unmarshal(token.Data, &t); err != nil {
+	if err := json.Unmarshal(tokenData, &t); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal token: %w", err)
 	}
 	return &t, nil
@@ -35,19 +63,52 @@ func (c *cliSession) GetRawToken() (*oauth2.Token, error) {
 
 // SetRawToken implements authorization_code.ISessionHooks.
 func (c *cliSession) SetRawToken(token *oauth2.Token) error {
+	key := fmt.Sprintf("%s_token", keyPrefix)
 
 	if token == nil {
-		return c.keyring.Remove(fmt.Sprintf("%s_token", keyPrefix))
+		return c.keyring.Remove(key)
 	}
 
 	t, err := json.Marshal(token)
 	if err != nil {
 		return fmt.Errorf("failed to marshal token: %w", err)
 	}
-	return c.keyring.Set(keyring.Item{
-		Key:  fmt.Sprintf("%s_token", keyPrefix),
-		Data: t,
-	})
+
+	const chunkSize = 1024
+	chunks := (len(t) + chunkSize - 1) / chunkSize
+
+	// Remove any existing chunks
+	for i := 0; ; i++ {
+		chunkKey := fmt.Sprintf("%s_chunk_%d", key, i)
+		if err := c.keyring.Remove(chunkKey); err != nil {
+			break
+		}
+	}
+
+	// Save chunks
+	for i := range chunks {
+		start := i * chunkSize
+		end := min(start+chunkSize, len(t))
+		chunkKey := fmt.Sprintf("%s_chunk_%d", key, i)
+		if err := c.keyring.Set(keyring.Item{
+			Key:  chunkKey,
+			Data: t[start:end],
+		}); err != nil {
+			return fmt.Errorf("failed to save token chunk %d: %w", i, err)
+		}
+	}
+
+	// Save chunk count
+	countKey := fmt.Sprintf("%s_chunk_count", key)
+	countData := fmt.Appendf(nil, "%d", chunks)
+	if err := c.keyring.Set(keyring.Item{
+		Key:  countKey,
+		Data: countData,
+	}); err != nil {
+		return fmt.Errorf("failed to save chunk count: %w", err)
+	}
+
+	return nil
 }
 
 // GetPostAuthRedirect implements authorization_code.SessionHooks.

--- a/frameworks/cli/cliSession_test.go
+++ b/frameworks/cli/cliSession_test.go
@@ -1,14 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/99designs/keyring"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 )
-
-type configMock struct {
-	SomeField string `mapstructure:"some_field"`
-}
 
 func TestNewCliSession(t *testing.T) {
 
@@ -18,4 +18,131 @@ func TestNewCliSession(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(session)
 
+}
+
+// mockKeyring implements keyring.Keyring for testing
+type mockKeyring struct {
+	items   map[string]keyring.Item
+	getErrs map[string]error
+}
+
+func (m *mockKeyring) Get(key string) (keyring.Item, error) {
+	if err, ok := m.getErrs[key]; ok {
+		return keyring.Item{}, err
+	}
+	item, ok := m.items[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+	return item, nil
+}
+func (m *mockKeyring) Set(item keyring.Item) error { m.items[item.Key] = item; return nil }
+func (m *mockKeyring) Remove(key string) error     { delete(m.items, key); return nil }
+func (m *mockKeyring) Keys() ([]string, error)     { return nil, nil }
+func (m *mockKeyring) Reset() error                { m.items = map[string]keyring.Item{}; return nil }
+
+// GetMetadata implements keyring.Keyring for testing.
+func (m *mockKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	return keyring.Metadata{}, nil
+}
+
+func TestCliSession_GetRawToken_SingleToken(t *testing.T) {
+	assert := assert.New(t)
+	token := &oauth2.Token{AccessToken: "abc", TokenType: "Bearer"}
+	data, _ := json.Marshal(token)
+	mk := &mockKeyring{
+		items: map[string]keyring.Item{
+			"kinde_token": {Key: "kinde_token", Data: data},
+		},
+		getErrs: map[string]error{
+			"kinde_chunk_count": keyring.ErrKeyNotFound,
+		},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.Nil(err)
+	assert.Equal(token.AccessToken, got.AccessToken)
+}
+
+func TestCliSession_GetRawToken_ChunkedToken(t *testing.T) {
+	assert := assert.New(t)
+	token := &oauth2.Token{AccessToken: "chunked", TokenType: "Bearer"}
+	data, _ := json.Marshal(token)
+	// Split into 2 chunks
+	chunk1 := data[:len(data)/2]
+	chunk2 := data[len(data)/2:]
+	mk := &mockKeyring{
+		items: map[string]keyring.Item{
+			"kinde_token_chunk_count": {Key: "kinde_token_chunk_count", Data: []byte("2")},
+			"kinde_token_chunk_0":     {Key: "kinde_token_chunk_0", Data: chunk1},
+			"kinde_token_chunk_1":     {Key: "kinde_token_chunk_1", Data: chunk2},
+		},
+		getErrs: map[string]error{},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.Nil(err)
+	assert.Equal(token.AccessToken, got.AccessToken)
+}
+
+func TestCliSession_GetRawToken_TokenNotFound(t *testing.T) {
+	assert := assert.New(t)
+	mk := &mockKeyring{
+		items:   map[string]keyring.Item{},
+		getErrs: map[string]error{"kinde_chunk_count": keyring.ErrKeyNotFound, "kinde_token": keyring.ErrKeyNotFound},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.NotNil(err)
+	assert.Nil(got)
+	assert.Contains(err.Error(), "failed to get token")
+}
+
+func TestCliSession_GetRawToken_ChunkCountParseError(t *testing.T) {
+	assert := assert.New(t)
+	mk := &mockKeyring{
+		items: map[string]keyring.Item{
+			"kinde_token_chunk_count": {Key: "kinde_token_chunk_count", Data: []byte("notanint")},
+		},
+		getErrs: map[string]error{},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.NotNil(err)
+	assert.Nil(got)
+	assert.Contains(err.Error(), "failed to parse chunk count")
+}
+
+func TestCliSession_GetRawToken_ChunkMissing(t *testing.T) {
+	assert := assert.New(t)
+	mk := &mockKeyring{
+		items: map[string]keyring.Item{
+			"kinde_token_chunk_count": {Key: "kinde_token_chunk_count", Data: []byte("1")},
+		},
+		getErrs: map[string]error{
+			"kinde_token_chunk_0": errors.New("not found"),
+		},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.NotNil(err)
+	assert.Nil(got)
+	assert.Contains(err.Error(), "failed to get token chunk 0")
+}
+
+func TestCliSession_GetRawToken_UnmarshalError(t *testing.T) {
+	assert := assert.New(t)
+	mk := &mockKeyring{
+		items: map[string]keyring.Item{
+			"kinde_token": {Key: "kinde_token", Data: []byte("notjson")},
+		},
+		getErrs: map[string]error{
+			"kinde_chunk_count": keyring.ErrKeyNotFound,
+		},
+	}
+	cs := &cliSession{keyring: mk}
+	got, err := cs.GetRawToken()
+	assert.NotNil(err)
+	assert.Nil(got)
+	assert.Contains(err.Error(), "failed to unmarshal token")
 }


### PR DESCRIPTION
Enhance the token handling logic to support chunked storage, allowing for larger tokens to be stored and retrieved efficiently. This change improves the GetRawToken and SetRawToken methods to handle both single and chunked tokens.