### PR TITLE
Add support for KINDE_KEYCHAIN_PASS environment variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,10 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/examples/cli/cmd/example-cli",
-      "args": ["whoami", "--kinde-domain", "https://${input:commandline}"]
+      "args": ["whoami", "--kinde-domain", "https://${input:commandline}"],
+      "env": {
+        "KINDE_KEYCHAIN_PASS": "some_super_secret"
+      }
     },
     {
       "name": "Launch example CLI - logout",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,10 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/examples/cli/cmd/example-cli",
-      "args": ["login", "--kinde-domain", "https://${input:commandline}"]
+      "args": ["login", "--kinde-domain", "https://${input:commandline}"],
+      "env": {
+        "KINDE_KEYCHAIN_PASS": "some_super_secret"
+      }
     },
     {
       "name": "Launch example CLI - whoami",

--- a/examples/cli/pkg/config/config.go
+++ b/examples/cli/pkg/config/config.go
@@ -14,7 +14,7 @@ type Config struct {
 }
 
 func NewDeviceAuthorizationFlow(issuerDomain string) (authorization_code.IDeviceAuthorizationFlow, error) {
-	cliSession, err := cli.NewCliSession(CLI_NAME)
+	cliSession, err := cli.NewCliSession(issuerDomain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}

--- a/frameworks/cli/cliSession.go
+++ b/frameworks/cli/cliSession.go
@@ -48,6 +48,8 @@ func (c *cliSession) SetCodeVerifier(codeVerifier string) error {
 }
 
 func (c *cliSession) getChunkCount(key string) (int, error) {
+	xx, _ := c.keyring.Keys()
+	fmt.Printf("Keys in keyring: %v\n", xx)
 	countItem, err := c.keyring.Get(key)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get token chunk count: %w", err)
@@ -195,25 +197,30 @@ func normalizeServiceName(name string) string {
 func NewCliSession(serviceName string) (authorization_code.ISessionHooks, error) {
 
 	// In NewCliSession:
+	getPassFunc := func(prompt string) (string, error) {
+		if pass := os.Getenv("KINDE_KEYCHAIN_PASS"); pass != "" {
+			return pass, nil
+		}
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			return "", fmt.Errorf("Cannot initialize keychain, please run in interactive terminal first to provide password or provide KINDE_KEYCHAIN_PASS environment variable")
+		}
+		fmt.Printf("%s", prompt)
+		password, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			fmt.Println("\nError reading password:", err)
+			return "", err
+		}
+		return string(password), nil
+	}
+	keychainName := fmt.Sprintf("kinde_cli/%s", normalizeServiceName(serviceName))
+	serviceName = fmt.Sprintf("%s", normalizeServiceName(serviceName))
 	ring, err := keyring.Open(keyring.Config{
 		KeychainTrustApplication: true,
 		ServiceName:              serviceName,
-		KeychainName:             fmt.Sprintf("kinde_cli/%s", normalizeServiceName(serviceName)),
-		KeychainPasswordFunc: func(prompt string) (string, error) {
-			if pass := os.Getenv("KINDE_KEYCHAIN_PASS"); pass != "" {
-				return pass, nil
-			}
-			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return "", fmt.Errorf("Cannot initialize keychain, please run in interactive terminal first to provide password or provide KINDE_KEYCHAIN_PASS environment variable")
-			}
-			fmt.Printf("%s", prompt)
-			password, err := term.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				fmt.Println("\nError reading password:", err)
-				return "", err
-			}
-			return string(password), nil
-		}})
+		KeychainName:             keychainName,
+		KeychainPasswordFunc:     getPassFunc,
+		FilePasswordFunc:         getPassFunc,
+	})
 
 	if err != nil {
 		return nil, err

--- a/frameworks/cli/cliSession.go
+++ b/frameworks/cli/cliSession.go
@@ -50,12 +50,12 @@ func (c *cliSession) SetCodeVerifier(codeVerifier string) error {
 func (c *cliSession) getChunkCount(key string) (int, error) {
 	countItem, err := c.keyring.Get(key)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get chunk count: %w", err)
+		return 0, fmt.Errorf("failed to get token chunk count: %w", err)
 	}
 
 	var chunks int
 	if _, err := fmt.Sscanf(string(countItem.Data), "%d", &chunks); err != nil {
-		return 0, fmt.Errorf("failed to parse chunk count: %w", err)
+		return 0, fmt.Errorf("failed to parse token chunk count: %w", err)
 	}
 	return chunks, nil
 }
@@ -183,14 +183,28 @@ func (c *cliSession) SetState(state string) error {
 	return fmt.Errorf("not supported in CLI session")
 }
 
+func normalizeServiceName(name string) string {
+	// Replace special characters and spaces that could cause issues in keychain
+	normalized := strings.ReplaceAll(name, "/", "_")
+	normalized = strings.ReplaceAll(normalized, ":", "_")
+	normalized = strings.ReplaceAll(normalized, ".", "_")
+	normalized = strings.ReplaceAll(normalized, " ", "_")
+	return normalized
+}
+
 func NewCliSession(serviceName string) (authorization_code.ISessionHooks, error) {
+
+	// In NewCliSession:
 	ring, err := keyring.Open(keyring.Config{
 		KeychainTrustApplication: true,
 		ServiceName:              serviceName,
-		KeychainName:             strings.ReplaceAll(serviceName, ".", "_"),
+		KeychainName:             fmt.Sprintf("kinde_cli/%s", normalizeServiceName(serviceName)),
 		KeychainPasswordFunc: func(prompt string) (string, error) {
+			if pass := os.Getenv("KINDE_KEYCHAIN_PASS"); pass != "" {
+				return pass, nil
+			}
 			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return "", fmt.Errorf("cannot initialize keychain, please run in interactive terminal first to provide password")
+				return "", fmt.Errorf("Cannot initialize keychain, please run in interactive terminal first to provide password or provide KINDE_KEYCHAIN_PASS environment variable")
 			}
 			fmt.Printf("%s", prompt)
 			password, err := term.ReadPassword(int(syscall.Stdin))

--- a/frameworks/cli/cliSession.go
+++ b/frameworks/cli/cliSession.go
@@ -48,8 +48,6 @@ func (c *cliSession) SetCodeVerifier(codeVerifier string) error {
 }
 
 func (c *cliSession) getChunkCount(key string) (int, error) {
-	xx, _ := c.keyring.Keys()
-	fmt.Printf("Keys in keyring: %v\n", xx)
 	countItem, err := c.keyring.Get(key)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get token chunk count: %w", err)
@@ -83,7 +81,7 @@ func (c *cliSession) GetRawToken() (*oauth2.Token, error) {
 	}
 
 	var tokenData []byte
-	for i := 0; i < chunks; i++ {
+	for i := range chunks {
 		chunkKey := fmt.Sprintf("%s_chunk_%d", key, i)
 		chunkItem, err := c.keyring.Get(chunkKey)
 		if err != nil {
@@ -194,7 +192,7 @@ func normalizeServiceName(name string) string {
 	return normalized
 }
 
-func NewCliSession(serviceName string) (authorization_code.ISessionHooks, error) {
+func NewCliSession(serviceName string, opts ...Option) (authorization_code.ISessionHooks, error) {
 
 	// In NewCliSession:
 	getPassFunc := func(prompt string) (string, error) {
@@ -212,15 +210,29 @@ func NewCliSession(serviceName string) (authorization_code.ISessionHooks, error)
 		}
 		return string(password), nil
 	}
+
+	// Default values
 	keychainName := fmt.Sprintf("kinde_cli/%s", normalizeServiceName(serviceName))
-	serviceName = fmt.Sprintf("%s", normalizeServiceName(serviceName))
-	ring, err := keyring.Open(keyring.Config{
-		KeychainTrustApplication: true,
-		ServiceName:              serviceName,
-		KeychainName:             keychainName,
-		KeychainPasswordFunc:     getPassFunc,
-		FilePasswordFunc:         getPassFunc,
-	})
+	serviceNameNorm := normalizeServiceName(serviceName)
+
+	// Collect options (could be passed in as variadic args to NewCliSession)
+	opts = append(opts,
+		WithAllowedBackends([]keyring.BackendType{keyring.WinCredBackend, keyring.KeychainBackend, keyring.FileBackend}),
+		WithKeychainTrustApplication(true),
+		WithServiceName(serviceNameNorm),
+		WithKeychainName(keychainName),
+		WithKeychainPasswordFunc(getPassFunc),
+		WithFilePasswordFunc(getPassFunc),
+		WithFileDir(fmt.Sprintf("~/.config/%s", serviceNameNorm)),
+	)
+
+	// Build config using options
+	var cfg keyring.Config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	ring, err := keyring.Open(cfg)
 
 	if err != nil {
 		return nil, err

--- a/frameworks/cli/cliSession_test.go
+++ b/frameworks/cli/cliSession_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"path"
 	"testing"
 
 	"github.com/99designs/keyring"
@@ -14,7 +15,8 @@ func TestNewCliSession(t *testing.T) {
 
 	assert := assert.New(t)
 
-	session, err := NewCliSession("test-cli")
+	opts := []Option{WithFileDir(path.Join(t.TempDir(), ".test_keyring")), WithAllowedBackends([]keyring.BackendType{keyring.FileBackend})}
+	session, err := NewCliSession("test-cli", opts...)
 	assert.Nil(err)
 	assert.NotNil(session)
 

--- a/frameworks/cli/options.go
+++ b/frameworks/cli/options.go
@@ -1,0 +1,54 @@
+package cli
+
+import "github.com/99designs/keyring"
+
+type Option func(*keyring.Config)
+
+// WithAllowedBackends sets the allowed backends for the keyring.
+func WithAllowedBackends(backends []keyring.BackendType) Option {
+	return func(cfg *keyring.Config) {
+		cfg.AllowedBackends = backends
+	}
+}
+
+// WithFileDir sets the file directory for the file backend.
+func WithFileDir(dir string) Option {
+	return func(cfg *keyring.Config) {
+		cfg.FileDir = dir
+	}
+}
+
+// WithServiceName sets the service name for the keyring.
+func WithServiceName(name string) Option {
+	return func(cfg *keyring.Config) {
+		cfg.ServiceName = name
+	}
+}
+
+// WithKeychainName sets the keychain name for the keyring.
+func WithKeychainName(name string) Option {
+	return func(cfg *keyring.Config) {
+		cfg.KeychainName = name
+	}
+}
+
+// WithKeychainPasswordFunc sets the password function for the keychain backend.
+func WithKeychainPasswordFunc(fn keyring.PromptFunc) Option {
+	return func(cfg *keyring.Config) {
+		cfg.KeychainPasswordFunc = fn
+	}
+}
+
+// WithFilePasswordFunc sets the password function for the file backend.
+func WithFilePasswordFunc(fn keyring.PromptFunc) Option {
+	return func(cfg *keyring.Config) {
+		cfg.FilePasswordFunc = fn
+	}
+}
+
+// WithKeychainTrustApplication sets whether to trust the application for the keychain backend.
+func WithKeychainTrustApplication(trust bool) Option {
+	return func(cfg *keyring.Config) {
+		cfg.KeychainTrustApplication = trust
+	}
+}

--- a/oauth2/authorization_code/token_source.go
+++ b/oauth2/authorization_code/token_source.go
@@ -36,7 +36,7 @@ func (t sessionTokenSource) validateToken(_ context.Context, token *oauth2.Token
 func (t sessionTokenSource) Token() (*oauth2.Token, error) {
 	token, err := t.flow.sessionHooks.GetRawToken()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get raw token: %w", err)
+		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
 	ts := t.flow.config.TokenSource(context.Background(), token)
 
@@ -49,6 +49,6 @@ func (t sessionTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("failed to validate token: %w", err)
 	}
 
-	t.flow.sessionHooks.SetRawToken(possiblyNewToken)
-	return possiblyNewToken, nil
+	err = t.flow.sessionHooks.SetRawToken(possiblyNewToken)
+	return possiblyNewToken, err
 }


### PR DESCRIPTION
Introduce support for the KINDE_KEYCHAIN_PASS environment variable in the CLI session initialization, improving error handling and consistency in token management. Refactor the session creation process to allow for configurable options and enhance logging for keyring operations.