### PR TITLE
fix(management_api): CreateUserIdentity response decodes identity_id …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- **Management API (generated):** Added `EffectiveIdentityID()` helper method to `CreateIdentityResponseIdentity`. The decoder now handles both `id` and `identity_id` JSON keys when creating identities, accommodating the API's alternate field name for existing enterprise identities.
+
 ### Breaking changes
 
 - **Management API (generated):** Response types for the delete API application scope operation were renamed to fix a typo: `DeleteAPIAppliationScope*` → `DeleteAPIApplicationScope*` (e.g. `DeleteAPIAppliationScopeBadRequest` → `DeleteAPIApplicationScopeBadRequest`). If you reference the old type names in your code, update them to the new spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 <!-- Ideally, this should get auto-generated via tools like [auto-changelog](https://github.com/CookPete/auto-changelog). Eventually, this will get set up as part of the repository template. -->
+
+## Unreleased
+
+### Breaking changes
+
+- **Management API (generated):** Response types for the delete API application scope operation were renamed to fix a typo: `DeleteAPIAppliationScope*` → `DeleteAPIApplicationScope*` (e.g. `DeleteAPIAppliationScopeBadRequest` → `DeleteAPIApplicationScopeBadRequest`). If you reference the old type names in your code, update them to the new spelling.

--- a/kinde/management_api/create_identity_response_helpers.go
+++ b/kinde/management_api/create_identity_response_helpers.go
@@ -1,0 +1,17 @@
+package management_api
+
+// EffectiveIdentityID returns the identity ID from the CreateIdentity response.
+// The API may return "id" (normal case) or "identity_id" (when creating with existing enterprise identity).
+// This helper returns whichever is set so callers get a single value.
+func (s *CreateIdentityResponseIdentity) EffectiveIdentityID() (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	if id, ok := s.ID.Get(); ok && id != "" {
+		return id, true
+	}
+	if id, ok := s.IdentityID.Get(); ok && id != "" {
+		return id, true
+	}
+	return "", false
+}

--- a/kinde/management_api/create_identity_response_test.go
+++ b/kinde/management_api/create_identity_response_test.go
@@ -1,0 +1,99 @@
+package management_api
+
+import (
+	"testing"
+
+	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateIdentityResponse_Decode_WithId verifies that a response with "id" field decodes correctly.
+func TestCreateIdentityResponse_Decode_WithId(t *testing.T) {
+	json := `{
+		"message": "Identity created",
+		"code": "IDENTITY_CREATED",
+		"identity": {
+			"id": "idl_abc123"
+		}
+	}`
+
+	d := jx.DecodeBytes([]byte(json))
+	var response CreateIdentityResponse
+
+	err := response.Decode(d)
+	require.NoError(t, err)
+
+	require.True(t, response.Identity.IsSet(), "Identity should be set")
+	identity, _ := response.Identity.Get()
+	assert.True(t, identity.ID.IsSet(), "Identity ID should be set")
+	id, ok := identity.ID.Get()
+	require.True(t, ok)
+	assert.Equal(t, "idl_abc123", id)
+
+	effectiveID, ok := identity.EffectiveIdentityID()
+	require.True(t, ok)
+	assert.Equal(t, "idl_abc123", effectiveID)
+}
+
+// TestCreateIdentityResponse_Decode_WithIdentityId verifies the bug fix: when the API returns
+// "identity_id" (e.g. for existing enterprise identity), the identity is decoded and EffectiveIdentityID works.
+func TestCreateIdentityResponse_Decode_WithIdentityId(t *testing.T) {
+	json := `{
+		"message": "Identity created",
+		"code": "IDENTITY_CREATED",
+		"identity": {
+			"identity_id": "idl_existing_enterprise_123"
+		}
+	}`
+
+	d := jx.DecodeBytes([]byte(json))
+	var response CreateIdentityResponse
+
+	err := response.Decode(d)
+	require.NoError(t, err)
+
+	require.True(t, response.Identity.IsSet(), "Identity should be set")
+	identity, _ := response.Identity.Get()
+	assert.True(t, identity.IdentityID.IsSet(), "IdentityID should be set (from identity_id field)")
+	id, ok := identity.IdentityID.Get()
+	require.True(t, ok)
+	assert.Equal(t, "idl_existing_enterprise_123", id)
+
+	effectiveID, ok := identity.EffectiveIdentityID()
+	require.True(t, ok, "EffectiveIdentityID should return the identity_id value")
+	assert.Equal(t, "idl_existing_enterprise_123", effectiveID)
+}
+
+// TestCreateIdentityResponseIdentity_Decode_IdentityIdField verifies the identity object
+// decoder accepts "identity_id" and populates IdentityID.
+func TestCreateIdentityResponseIdentity_Decode_IdentityIdField(t *testing.T) {
+	json := `{"identity_id": "idl_xyz789"}`
+
+	d := jx.DecodeBytes([]byte(json))
+	var identity CreateIdentityResponseIdentity
+
+	err := identity.Decode(d)
+	require.NoError(t, err)
+
+	assert.True(t, identity.IdentityID.IsSet(), "IdentityID should be set from identity_id field")
+	id, ok := identity.IdentityID.Get()
+	require.True(t, ok)
+	assert.Equal(t, "idl_xyz789", id)
+
+	effectiveID, ok := identity.EffectiveIdentityID()
+	require.True(t, ok)
+	assert.Equal(t, "idl_xyz789", effectiveID)
+}
+
+// TestCreateIdentityResponseIdentity_EffectiveIdentityID_prefers_id verifies EffectiveIdentityID
+// returns ID when both ID and IdentityID are set (e.g. spec allows both).
+func TestCreateIdentityResponseIdentity_EffectiveIdentityID_prefers_id(t *testing.T) {
+	identity := CreateIdentityResponseIdentity{}
+	identity.SetID(NewOptString("idl_primary"))
+	identity.SetIdentityID(NewOptString("idl_secondary"))
+
+	effectiveID, ok := identity.EffectiveIdentityID()
+	require.True(t, ok)
+	assert.Equal(t, "idl_primary", effectiveID)
+}

--- a/kinde/management_api/generate.go
+++ b/kinde/management_api/generate.go
@@ -1,4 +1,4 @@
 package management_api
 
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen --target . -package management_api --clean https://api-spec.kinde.com/kinde-management-api-spec.yaml
+//go:generate go run github.com/ogen-go/ogen/cmd/ogen --target . -package management_api --clean spec/kinde-management-api-spec.yaml
 //go:generate go run fix_optstring.go

--- a/kinde/management_api/oas_client_gen.go
+++ b/kinde/management_api/oas_client_gen.go
@@ -295,7 +295,7 @@ type Invoker interface {
 	//
 	// DELETE /api/v1/apis/{api_id}
 	DeleteAPI(ctx context.Context, params DeleteAPIParams) (DeleteAPIRes, error)
-	// DeleteAPIAppliationScope invokes deleteAPIAppliationScope operation.
+	// DeleteAPIApplicationScope invokes deleteAPIApplicationScope operation.
 	//
 	// Delete an API application scope you previously created.
 	// <div>
@@ -303,7 +303,7 @@ type Invoker interface {
 	// </div>.
 	//
 	// DELETE /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}
-	DeleteAPIAppliationScope(ctx context.Context, params DeleteAPIAppliationScopeParams) (DeleteAPIAppliationScopeRes, error)
+	DeleteAPIApplicationScope(ctx context.Context, params DeleteAPIApplicationScopeParams) (DeleteAPIApplicationScopeRes, error)
 	// DeleteAPIScope invokes deleteAPIScope operation.
 	//
 	// Delete an API scope you previously created.
@@ -5193,7 +5193,7 @@ func (c *Client) sendDeleteAPI(ctx context.Context, params DeleteAPIParams) (res
 	return result, nil
 }
 
-// DeleteAPIAppliationScope invokes deleteAPIAppliationScope operation.
+// DeleteAPIApplicationScope invokes deleteAPIApplicationScope operation.
 //
 // Delete an API application scope you previously created.
 // <div>
@@ -5201,14 +5201,14 @@ func (c *Client) sendDeleteAPI(ctx context.Context, params DeleteAPIParams) (res
 // </div>.
 //
 // DELETE /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}
-func (c *Client) DeleteAPIAppliationScope(ctx context.Context, params DeleteAPIAppliationScopeParams) (DeleteAPIAppliationScopeRes, error) {
-	res, err := c.sendDeleteAPIAppliationScope(ctx, params)
+func (c *Client) DeleteAPIApplicationScope(ctx context.Context, params DeleteAPIApplicationScopeParams) (DeleteAPIApplicationScopeRes, error) {
+	res, err := c.sendDeleteAPIApplicationScope(ctx, params)
 	return res, err
 }
 
-func (c *Client) sendDeleteAPIAppliationScope(ctx context.Context, params DeleteAPIAppliationScopeParams) (res DeleteAPIAppliationScopeRes, err error) {
+func (c *Client) sendDeleteAPIApplicationScope(ctx context.Context, params DeleteAPIApplicationScopeParams) (res DeleteAPIApplicationScopeRes, err error) {
 	otelAttrs := []attribute.KeyValue{
-		otelogen.OperationID("deleteAPIAppliationScope"),
+		otelogen.OperationID("deleteAPIApplicationScope"),
 		semconv.HTTPRequestMethodKey.String("DELETE"),
 		semconv.HTTPRouteKey.String("/api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}"),
 	}
@@ -5225,7 +5225,7 @@ func (c *Client) sendDeleteAPIAppliationScope(ctx context.Context, params Delete
 	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 
 	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, DeleteAPIAppliationScopeOperation,
+	ctx, span := c.cfg.Tracer.Start(ctx, DeleteAPIApplicationScopeOperation,
 		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
@@ -5313,7 +5313,7 @@ func (c *Client) sendDeleteAPIAppliationScope(ctx context.Context, params Delete
 		var satisfied bitset
 		{
 			stage = "Security:KindeBearerAuth"
-			switch err := c.securityKindeBearerAuth(ctx, DeleteAPIAppliationScopeOperation, r); {
+			switch err := c.securityKindeBearerAuth(ctx, DeleteAPIApplicationScopeOperation, r); {
 			case err == nil: // if NO error
 				satisfied[0] |= 1 << 0
 			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
@@ -5349,7 +5349,7 @@ func (c *Client) sendDeleteAPIAppliationScope(ctx context.Context, params Delete
 	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
-	result, err := decodeDeleteAPIAppliationScopeResponse(resp)
+	result, err := decodeDeleteAPIApplicationScopeResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -16650,6 +16650,23 @@ func (c *Client) sendGetUsers(ctx context.Context, params GetUsersParams) (res G
 			return res, errors.Wrap(err, "encode query")
 		}
 	}
+	{
+		// Encode "active_since" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "active_since",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.ActiveSince.Get(); ok {
+				return e.EncodeValue(conv.DateTimeToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
 	u.RawQuery = q.Values().Encode()
 
 	stage = "EncodeRequest"
@@ -19433,6 +19450,23 @@ func (c *Client) sendSearchUsers(ctx context.Context, params SearchUsersParams) 
 
 		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
 			if val, ok := params.Query.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "api_scopes" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "api_scopes",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.APIScopes.Get(); ok {
 				return e.EncodeValue(conv.StringToString(val))
 			}
 			return nil

--- a/kinde/management_api/oas_handlers_gen.go
+++ b/kinde/management_api/oas_handlers_gen.go
@@ -5590,7 +5590,7 @@ func (s *Server) handleDeleteAPIRequest(args [1]string, argsEscaped bool, w http
 	}
 }
 
-// handleDeleteAPIAppliationScopeRequest handles deleteAPIAppliationScope operation.
+// handleDeleteAPIApplicationScopeRequest handles deleteAPIApplicationScope operation.
 //
 // Delete an API application scope you previously created.
 // <div>
@@ -5598,17 +5598,17 @@ func (s *Server) handleDeleteAPIRequest(args [1]string, argsEscaped bool, w http
 // </div>.
 //
 // DELETE /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}
-func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleDeleteAPIApplicationScopeRequest(args [3]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
-		otelogen.OperationID("deleteAPIAppliationScope"),
+		otelogen.OperationID("deleteAPIApplicationScope"),
 		semconv.HTTPRequestMethodKey.String("DELETE"),
 		semconv.HTTPRouteKey.String("/api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}"),
 	}
 
 	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), DeleteAPIAppliationScopeOperation,
+	ctx, span := s.cfg.Tracer.Start(r.Context(), DeleteAPIApplicationScopeOperation,
 		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
@@ -5663,15 +5663,15 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 		}
 		err          error
 		opErrContext = ogenerrors.OperationContext{
-			Name: DeleteAPIAppliationScopeOperation,
-			ID:   "deleteAPIAppliationScope",
+			Name: DeleteAPIApplicationScopeOperation,
+			ID:   "deleteAPIApplicationScope",
 		}
 	)
 	{
 		type bitset = [1]uint8
 		var satisfied bitset
 		{
-			sctx, ok, err := s.securityKindeBearerAuth(ctx, DeleteAPIAppliationScopeOperation, r)
+			sctx, ok, err := s.securityKindeBearerAuth(ctx, DeleteAPIApplicationScopeOperation, r)
 			if err != nil {
 				err = &ogenerrors.SecurityError{
 					OperationContext: opErrContext,
@@ -5711,7 +5711,7 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 			return
 		}
 	}
-	params, err := decodeDeleteAPIAppliationScopeParams(args, argsEscaped, r)
+	params, err := decodeDeleteAPIApplicationScopeParams(args, argsEscaped, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
 			OperationContext: opErrContext,
@@ -5722,13 +5722,13 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 		return
 	}
 
-	var response DeleteAPIAppliationScopeRes
+	var response DeleteAPIApplicationScopeRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
-			OperationName:    DeleteAPIAppliationScopeOperation,
+			OperationName:    DeleteAPIApplicationScopeOperation,
 			OperationSummary: "Delete API application scope",
-			OperationID:      "deleteAPIAppliationScope",
+			OperationID:      "deleteAPIApplicationScope",
 			Body:             nil,
 			Params: middleware.Parameters{
 				{
@@ -5749,8 +5749,8 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 
 		type (
 			Request  = struct{}
-			Params   = DeleteAPIAppliationScopeParams
-			Response = DeleteAPIAppliationScopeRes
+			Params   = DeleteAPIApplicationScopeParams
+			Response = DeleteAPIApplicationScopeRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,
@@ -5759,14 +5759,14 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 		](
 			m,
 			mreq,
-			unpackDeleteAPIAppliationScopeParams,
+			unpackDeleteAPIApplicationScopeParams,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.DeleteAPIAppliationScope(ctx, params)
+				response, err = s.h.DeleteAPIApplicationScope(ctx, params)
 				return response, err
 			},
 		)
 	} else {
-		response, err = s.h.DeleteAPIAppliationScope(ctx, params)
+		response, err = s.h.DeleteAPIApplicationScope(ctx, params)
 	}
 	if err != nil {
 		defer recordError("Internal", err)
@@ -5774,7 +5774,7 @@ func (s *Server) handleDeleteAPIAppliationScopeRequest(args [3]string, argsEscap
 		return
 	}
 
-	if err := encodeDeleteAPIAppliationScopeResponse(response, w, span); err != nil {
+	if err := encodeDeleteAPIApplicationScopeResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -20739,6 +20739,10 @@ func (s *Server) handleGetUsersRequest(args [0]string, argsEscaped bool, w http.
 					Name: "has_organization",
 					In:   "query",
 				}: params.HasOrganization,
+				{
+					Name: "active_since",
+					In:   "query",
+				}: params.ActiveSince,
 			},
 			Raw: r,
 		}
@@ -24693,6 +24697,10 @@ func (s *Server) handleSearchUsersRequest(args [0]string, argsEscaped bool, w ht
 					Name: "query",
 					In:   "query",
 				}: params.Query,
+				{
+					Name: "api_scopes",
+					In:   "query",
+				}: params.APIScopes,
 				{
 					Name: "properties",
 					In:   "query",

--- a/kinde/management_api/oas_interfaces_gen.go
+++ b/kinde/management_api/oas_interfaces_gen.go
@@ -113,8 +113,8 @@ type CreateWebHookRes interface {
 	createWebHookRes()
 }
 
-type DeleteAPIAppliationScopeRes interface {
-	deleteAPIAppliationScopeRes()
+type DeleteAPIApplicationScopeRes interface {
+	deleteAPIApplicationScopeRes()
 }
 
 type DeleteAPIRes interface {

--- a/kinde/management_api/oas_json_gen.go
+++ b/kinde/management_api/oas_json_gen.go
@@ -3093,6 +3093,10 @@ func (s *CreateApiKeyReq) encodeFields(e *jx.Encoder) {
 		e.Str(s.Name)
 	}
 	{
+		e.FieldStart("type")
+		s.Type.Encode(e)
+	}
+	{
 		e.FieldStart("api_id")
 		e.Str(s.APIID)
 	}
@@ -3116,12 +3120,13 @@ func (s *CreateApiKeyReq) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfCreateApiKeyReq = [5]string{
+var jsonFieldsNameOfCreateApiKeyReq = [6]string{
 	0: "name",
-	1: "api_id",
-	2: "scope_ids",
-	3: "user_id",
-	4: "org_code",
+	1: "type",
+	2: "api_id",
+	3: "scope_ids",
+	4: "user_id",
+	5: "org_code",
 }
 
 // Decode decodes CreateApiKeyReq from json.
@@ -3145,8 +3150,18 @@ func (s *CreateApiKeyReq) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"name\"")
 			}
-		case "api_id":
+		case "type":
 			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.Type.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"type\"")
+			}
+		case "api_id":
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				v, err := d.Str()
 				s.APIID = string(v)
@@ -3197,7 +3212,7 @@ func (s *CreateApiKeyReq) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -3239,6 +3254,48 @@ func (s *CreateApiKeyReq) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *CreateApiKeyReq) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes CreateApiKeyReqType as json.
+func (s CreateApiKeyReqType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes CreateApiKeyReqType from json.
+func (s *CreateApiKeyReqType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode CreateApiKeyReqType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch CreateApiKeyReqType(v) {
+	case CreateApiKeyReqTypeUser:
+		*s = CreateApiKeyReqTypeUser
+	case CreateApiKeyReqTypeOrganization:
+		*s = CreateApiKeyReqTypeOrganization
+	case CreateApiKeyReqTypeEnvironment:
+		*s = CreateApiKeyReqTypeEnvironment
+	default:
+		*s = CreateApiKeyReqType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s CreateApiKeyReqType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *CreateApiKeyReqType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -4825,14 +4882,6 @@ func (s *CreateConnectionReqOptions) Decode(d *jx.Decoder) error {
 				}
 				found = true
 				s.Type = match
-			case "saml_acs_url":
-				match := CreateConnectionReqOptions2CreateConnectionReqOptions
-				if found && s.Type != match {
-					s.Type = ""
-					return errors.Errorf("multiple oneOf matches: (%v, %v)", s.Type, match)
-				}
-				found = true
-				s.Type = match
 			case "saml_idp_metadata_url":
 				match := CreateConnectionReqOptions2CreateConnectionReqOptions
 				if found && s.Type != match {
@@ -5374,12 +5423,6 @@ func (s *CreateConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.SamlAcsURL.Set {
-			e.FieldStart("saml_acs_url")
-			s.SamlAcsURL.Encode(e)
-		}
-	}
-	{
 		if s.SamlIdpMetadataURL.Set {
 			e.FieldStart("saml_idp_metadata_url")
 			s.SamlIdpMetadataURL.Encode(e)
@@ -5447,21 +5490,20 @@ func (s *CreateConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfCreateConnectionReqOptions2 = [14]string{
+var jsonFieldsNameOfCreateConnectionReqOptions2 = [13]string{
 	0:  "home_realm_domains",
 	1:  "saml_entity_id",
-	2:  "saml_acs_url",
-	3:  "saml_idp_metadata_url",
-	4:  "saml_sign_in_url",
-	5:  "saml_email_key_attr",
-	6:  "saml_first_name_key_attr",
-	7:  "saml_last_name_key_attr",
-	8:  "is_create_missing_user",
-	9:  "is_force_show_sso_button",
-	10: "upstream_params",
-	11: "saml_signing_certificate",
-	12: "saml_signing_private_key",
-	13: "is_auto_join_organization_enabled",
+	2:  "saml_idp_metadata_url",
+	3:  "saml_sign_in_url",
+	4:  "saml_email_key_attr",
+	5:  "saml_first_name_key_attr",
+	6:  "saml_last_name_key_attr",
+	7:  "is_create_missing_user",
+	8:  "is_force_show_sso_button",
+	9:  "upstream_params",
+	10: "saml_signing_certificate",
+	11: "saml_signing_private_key",
+	12: "is_auto_join_organization_enabled",
 }
 
 // Decode decodes CreateConnectionReqOptions2 from json.
@@ -5500,16 +5542,6 @@ func (s *CreateConnectionReqOptions2) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"saml_entity_id\"")
-			}
-		case "saml_acs_url":
-			if err := func() error {
-				s.SamlAcsURL.Reset()
-				if err := s.SamlAcsURL.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"saml_acs_url\"")
 			}
 		case "saml_idp_metadata_url":
 			if err := func() error {
@@ -5753,6 +5785,14 @@ func (s *CreateConnectionReqStrategy) Decode(d *jx.Decoder) error {
 		*s = CreateConnectionReqStrategyOAuth2Xero
 	case CreateConnectionReqStrategySamlCustom:
 		*s = CreateConnectionReqStrategySamlCustom
+	case CreateConnectionReqStrategySamlCloudflare:
+		*s = CreateConnectionReqStrategySamlCloudflare
+	case CreateConnectionReqStrategySamlOkta:
+		*s = CreateConnectionReqStrategySamlOkta
+	case CreateConnectionReqStrategySamlMicrosoft:
+		*s = CreateConnectionReqStrategySamlMicrosoft
+	case CreateConnectionReqStrategySamlGoogle:
+		*s = CreateConnectionReqStrategySamlGoogle
 	case CreateConnectionReqStrategyWsfedAzureAd:
 		*s = CreateConnectionReqStrategyWsfedAzureAd
 	default:
@@ -6752,10 +6792,17 @@ func (s *CreateIdentityResponseIdentity) encodeFields(e *jx.Encoder) {
 			s.ID.Encode(e)
 		}
 	}
+	{
+		if s.IdentityID.Set {
+			e.FieldStart("identity_id")
+			s.IdentityID.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfCreateIdentityResponseIdentity = [1]string{
+var jsonFieldsNameOfCreateIdentityResponseIdentity = [2]string{
 	0: "id",
+	1: "identity_id",
 }
 
 // Decode decodes CreateIdentityResponseIdentity from json.
@@ -6775,6 +6822,16 @@ func (s *CreateIdentityResponseIdentity) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"id\"")
+			}
+		case "identity_id":
+			if err := func() error {
+				s.IdentityID.Reset()
+				if err := s.IdentityID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"identity_id\"")
 			}
 		default:
 			return d.Skip()
@@ -10600,17 +10657,17 @@ func (s *CreateWebhookResponseWebhook) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes DeleteAPIAppliationScopeBadRequest as json.
-func (s *DeleteAPIAppliationScopeBadRequest) Encode(e *jx.Encoder) {
+// Encode encodes DeleteAPIApplicationScopeBadRequest as json.
+func (s *DeleteAPIApplicationScopeBadRequest) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes DeleteAPIAppliationScopeBadRequest from json.
-func (s *DeleteAPIAppliationScopeBadRequest) Decode(d *jx.Decoder) error {
+// Decode decodes DeleteAPIApplicationScopeBadRequest from json.
+func (s *DeleteAPIApplicationScopeBadRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode DeleteAPIAppliationScopeBadRequest to nil")
+		return errors.New("invalid: unable to decode DeleteAPIApplicationScopeBadRequest to nil")
 	}
 	var unwrapped ErrorResponse
 	if err := func() error {
@@ -10621,34 +10678,34 @@ func (s *DeleteAPIAppliationScopeBadRequest) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = DeleteAPIAppliationScopeBadRequest(unwrapped)
+	*s = DeleteAPIApplicationScopeBadRequest(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *DeleteAPIAppliationScopeBadRequest) MarshalJSON() ([]byte, error) {
+func (s *DeleteAPIApplicationScopeBadRequest) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DeleteAPIAppliationScopeBadRequest) UnmarshalJSON(data []byte) error {
+func (s *DeleteAPIApplicationScopeBadRequest) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes DeleteAPIAppliationScopeForbidden as json.
-func (s *DeleteAPIAppliationScopeForbidden) Encode(e *jx.Encoder) {
+// Encode encodes DeleteAPIApplicationScopeForbidden as json.
+func (s *DeleteAPIApplicationScopeForbidden) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes DeleteAPIAppliationScopeForbidden from json.
-func (s *DeleteAPIAppliationScopeForbidden) Decode(d *jx.Decoder) error {
+// Decode decodes DeleteAPIApplicationScopeForbidden from json.
+func (s *DeleteAPIApplicationScopeForbidden) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode DeleteAPIAppliationScopeForbidden to nil")
+		return errors.New("invalid: unable to decode DeleteAPIApplicationScopeForbidden to nil")
 	}
 	var unwrapped ErrorResponse
 	if err := func() error {
@@ -10659,34 +10716,34 @@ func (s *DeleteAPIAppliationScopeForbidden) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = DeleteAPIAppliationScopeForbidden(unwrapped)
+	*s = DeleteAPIApplicationScopeForbidden(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *DeleteAPIAppliationScopeForbidden) MarshalJSON() ([]byte, error) {
+func (s *DeleteAPIApplicationScopeForbidden) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DeleteAPIAppliationScopeForbidden) UnmarshalJSON(data []byte) error {
+func (s *DeleteAPIApplicationScopeForbidden) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes DeleteAPIAppliationScopeTooManyRequests as json.
-func (s *DeleteAPIAppliationScopeTooManyRequests) Encode(e *jx.Encoder) {
+// Encode encodes DeleteAPIApplicationScopeTooManyRequests as json.
+func (s *DeleteAPIApplicationScopeTooManyRequests) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes DeleteAPIAppliationScopeTooManyRequests from json.
-func (s *DeleteAPIAppliationScopeTooManyRequests) Decode(d *jx.Decoder) error {
+// Decode decodes DeleteAPIApplicationScopeTooManyRequests from json.
+func (s *DeleteAPIApplicationScopeTooManyRequests) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode DeleteAPIAppliationScopeTooManyRequests to nil")
+		return errors.New("invalid: unable to decode DeleteAPIApplicationScopeTooManyRequests to nil")
 	}
 	var unwrapped ErrorResponse
 	if err := func() error {
@@ -10697,19 +10754,19 @@ func (s *DeleteAPIAppliationScopeTooManyRequests) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = DeleteAPIAppliationScopeTooManyRequests(unwrapped)
+	*s = DeleteAPIApplicationScopeTooManyRequests(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *DeleteAPIAppliationScopeTooManyRequests) MarshalJSON() ([]byte, error) {
+func (s *DeleteAPIApplicationScopeTooManyRequests) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DeleteAPIAppliationScopeTooManyRequests) UnmarshalJSON(data []byte) error {
+func (s *DeleteAPIApplicationScopeTooManyRequests) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -23371,6 +23428,16 @@ func (s *GetOrganizationResponse) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.AllowedDomains != nil {
+			e.FieldStart("allowed_domains")
+			e.ArrStart()
+			for _, elem := range s.AllowedDomains {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		if s.LinkColor.Set {
 			e.FieldStart("link_color")
 			s.LinkColor.Encode(e)
@@ -23480,7 +23547,7 @@ func (s *GetOrganizationResponse) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetOrganizationResponse = [28]string{
+var jsonFieldsNameOfGetOrganizationResponse = [29]string{
 	0:  "code",
 	1:  "name",
 	2:  "handle",
@@ -23491,24 +23558,25 @@ var jsonFieldsNameOfGetOrganizationResponse = [28]string{
 	7:  "logo_dark",
 	8:  "favicon_svg",
 	9:  "favicon_fallback",
-	10: "link_color",
-	11: "background_color",
-	12: "button_color",
-	13: "button_text_color",
-	14: "link_color_dark",
-	15: "background_color_dark",
-	16: "button_text_color_dark",
-	17: "button_color_dark",
-	18: "button_border_radius",
-	19: "card_border_radius",
-	20: "input_border_radius",
-	21: "theme_code",
-	22: "color_scheme",
-	23: "created_on",
-	24: "is_allow_registrations",
-	25: "sender_name",
-	26: "sender_email",
-	27: "billing",
+	10: "allowed_domains",
+	11: "link_color",
+	12: "background_color",
+	13: "button_color",
+	14: "button_text_color",
+	15: "link_color_dark",
+	16: "background_color_dark",
+	17: "button_text_color_dark",
+	18: "button_color_dark",
+	19: "button_border_radius",
+	20: "card_border_radius",
+	21: "input_border_radius",
+	22: "theme_code",
+	23: "color_scheme",
+	24: "created_on",
+	25: "is_allow_registrations",
+	26: "sender_name",
+	27: "sender_email",
+	28: "billing",
 }
 
 // Decode decodes GetOrganizationResponse from json.
@@ -23618,6 +23686,25 @@ func (s *GetOrganizationResponse) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"favicon_fallback\"")
+			}
+		case "allowed_domains":
+			if err := func() error {
+				s.AllowedDomains = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.AllowedDomains = append(s.AllowedDomains, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"allowed_domains\"")
 			}
 		case "link_color":
 			if err := func() error {
@@ -31870,6 +31957,67 @@ func (s *OptNilUUID) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes []UsersResponseUsersItemLastOrganizationSignInsItem as json.
+func (o OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	e.ArrStart()
+	for _, elem := range o.Value {
+		elem.Encode(e)
+	}
+	e.ArrEnd()
+}
+
+// Decode decodes []UsersResponseUsersItemLastOrganizationSignInsItem from json.
+func (o *OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v []UsersResponseUsersItemLastOrganizationSignInsItem
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	o.Value = make([]UsersResponseUsersItemLastOrganizationSignInsItem, 0)
+	if err := d.Arr(func(d *jx.Decoder) error {
+		var elem UsersResponseUsersItemLastOrganizationSignInsItem
+		if err := elem.Decode(d); err != nil {
+			return err
+		}
+		o.Value = append(o.Value, elem)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes NotFoundResponseErrors as json.
 func (o OptNotFoundResponseErrors) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -32548,6 +32696,39 @@ func (s *OptUpdateWebhookResponseWebhook) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes UserBilling as json.
+func (o OptUserBilling) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes UserBilling from json.
+func (o *OptUserBilling) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptUserBilling to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptUserBilling) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptUserBilling) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes UserIdentityResult as json.
 func (o OptUserIdentityResult) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -32820,6 +33001,12 @@ func (s *OrganizationUser) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.IsSuspended.Set {
+			e.FieldStart("is_suspended")
+			s.IsSuspended.Encode(e)
+		}
+	}
+	{
 		if s.Roles != nil {
 			e.FieldStart("roles")
 			e.ArrStart()
@@ -32831,7 +33018,7 @@ func (s *OrganizationUser) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfOrganizationUser = [9]string{
+var jsonFieldsNameOfOrganizationUser = [10]string{
 	0: "id",
 	1: "email",
 	2: "full_name",
@@ -32840,7 +33027,8 @@ var jsonFieldsNameOfOrganizationUser = [9]string{
 	5: "picture",
 	6: "joined_on",
 	7: "last_accessed_on",
-	8: "roles",
+	8: "is_suspended",
+	9: "roles",
 }
 
 // Decode decodes OrganizationUser from json.
@@ -32930,6 +33118,16 @@ func (s *OrganizationUser) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"last_accessed_on\"")
+			}
+		case "is_suspended":
+			if err := func() error {
+				s.IsSuspended.Reset()
+				if err := s.IsSuspended.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_suspended\"")
 			}
 		case "roles":
 			if err := func() error {
@@ -34983,14 +35181,6 @@ func (s *ReplaceConnectionReqOptions) Decode(d *jx.Decoder) error {
 				}
 				found = true
 				s.Type = match
-			case "saml_acs_url":
-				match := ReplaceConnectionReqOptions2ReplaceConnectionReqOptions
-				if found && s.Type != match {
-					s.Type = ""
-					return errors.Errorf("multiple oneOf matches: (%v, %v)", s.Type, match)
-				}
-				found = true
-				s.Type = match
 			case "saml_idp_metadata_url":
 				match := ReplaceConnectionReqOptions2ReplaceConnectionReqOptions
 				if found && s.Type != match {
@@ -35507,12 +35697,6 @@ func (s *ReplaceConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.SamlAcsURL.Set {
-			e.FieldStart("saml_acs_url")
-			s.SamlAcsURL.Encode(e)
-		}
-	}
-	{
 		if s.SamlIdpMetadataURL.Set {
 			e.FieldStart("saml_idp_metadata_url")
 			s.SamlIdpMetadataURL.Encode(e)
@@ -35568,19 +35752,18 @@ func (s *ReplaceConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfReplaceConnectionReqOptions2 = [12]string{
+var jsonFieldsNameOfReplaceConnectionReqOptions2 = [11]string{
 	0:  "home_realm_domains",
 	1:  "saml_entity_id",
-	2:  "saml_acs_url",
-	3:  "saml_idp_metadata_url",
-	4:  "saml_email_key_attr",
-	5:  "saml_first_name_key_attr",
-	6:  "saml_last_name_key_attr",
-	7:  "is_create_missing_user",
-	8:  "is_force_show_sso_button",
-	9:  "upstream_params",
-	10: "saml_signing_certificate",
-	11: "saml_signing_private_key",
+	2:  "saml_idp_metadata_url",
+	3:  "saml_email_key_attr",
+	4:  "saml_first_name_key_attr",
+	5:  "saml_last_name_key_attr",
+	6:  "is_create_missing_user",
+	7:  "is_force_show_sso_button",
+	8:  "upstream_params",
+	9:  "saml_signing_certificate",
+	10: "saml_signing_private_key",
 }
 
 // Decode decodes ReplaceConnectionReqOptions2 from json.
@@ -35619,16 +35802,6 @@ func (s *ReplaceConnectionReqOptions2) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"saml_entity_id\"")
-			}
-		case "saml_acs_url":
-			if err := func() error {
-				s.SamlAcsURL.Reset()
-				if err := s.SamlAcsURL.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"saml_acs_url\"")
 			}
 		case "saml_idp_metadata_url":
 			if err := func() error {
@@ -38279,9 +38452,19 @@ func (s *SearchUsersResponseResultsItem) encodeFields(e *jx.Encoder) {
 			s.Properties.Encode(e)
 		}
 	}
+	{
+		if s.APIScopes != nil {
+			e.FieldStart("api_scopes")
+			e.ArrStart()
+			for _, elem := range s.APIScopes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfSearchUsersResponseResultsItem = [15]string{
+var jsonFieldsNameOfSearchUsersResponseResultsItem = [16]string{
 	0:  "id",
 	1:  "provided_id",
 	2:  "email",
@@ -38297,6 +38480,7 @@ var jsonFieldsNameOfSearchUsersResponseResultsItem = [15]string{
 	12: "organizations",
 	13: "identities",
 	14: "properties",
+	15: "api_scopes",
 }
 
 // Decode decodes SearchUsersResponseResultsItem from json.
@@ -38473,6 +38657,23 @@ func (s *SearchUsersResponseResultsItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"properties\"")
 			}
+		case "api_scopes":
+			if err := func() error {
+				s.APIScopes = make([]SearchUsersResponseResultsItemAPIScopesItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem SearchUsersResponseResultsItemAPIScopesItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.APIScopes = append(s.APIScopes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"api_scopes\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -38493,6 +38694,103 @@ func (s *SearchUsersResponseResultsItem) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SearchUsersResponseResultsItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.OrgCode.Set {
+			e.FieldStart("org_code")
+			s.OrgCode.Encode(e)
+		}
+	}
+	{
+		if s.Scope.Set {
+			e.FieldStart("scope")
+			s.Scope.Encode(e)
+		}
+	}
+	{
+		if s.APIID.Set {
+			e.FieldStart("api_id")
+			s.APIID.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfSearchUsersResponseResultsItemAPIScopesItem = [3]string{
+	0: "org_code",
+	1: "scope",
+	2: "api_id",
+}
+
+// Decode decodes SearchUsersResponseResultsItemAPIScopesItem from json.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SearchUsersResponseResultsItemAPIScopesItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "org_code":
+			if err := func() error {
+				s.OrgCode.Reset()
+				if err := s.OrgCode.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"org_code\"")
+			}
+		case "scope":
+			if err := func() error {
+				s.Scope.Reset()
+				if err := s.Scope.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"scope\"")
+			}
+		case "api_id":
+			if err := func() error {
+				s.APIID.Reset()
+				if err := s.APIID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"api_id\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode SearchUsersResponseResultsItemAPIScopesItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -41234,14 +41532,6 @@ func (s *UpdateConnectionReqOptions) Decode(d *jx.Decoder) error {
 				}
 				found = true
 				s.Type = match
-			case "saml_acs_url":
-				match := UpdateConnectionReqOptions2UpdateConnectionReqOptions
-				if found && s.Type != match {
-					s.Type = ""
-					return errors.Errorf("multiple oneOf matches: (%v, %v)", s.Type, match)
-				}
-				found = true
-				s.Type = match
 			case "saml_idp_metadata_url":
 				match := UpdateConnectionReqOptions2UpdateConnectionReqOptions
 				if found && s.Type != match {
@@ -41758,12 +42048,6 @@ func (s *UpdateConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.SamlAcsURL.Set {
-			e.FieldStart("saml_acs_url")
-			s.SamlAcsURL.Encode(e)
-		}
-	}
-	{
 		if s.SamlIdpMetadataURL.Set {
 			e.FieldStart("saml_idp_metadata_url")
 			s.SamlIdpMetadataURL.Encode(e)
@@ -41819,19 +42103,18 @@ func (s *UpdateConnectionReqOptions2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUpdateConnectionReqOptions2 = [12]string{
+var jsonFieldsNameOfUpdateConnectionReqOptions2 = [11]string{
 	0:  "home_realm_domains",
 	1:  "saml_entity_id",
-	2:  "saml_acs_url",
-	3:  "saml_idp_metadata_url",
-	4:  "saml_email_key_attr",
-	5:  "saml_first_name_key_attr",
-	6:  "saml_last_name_key_attr",
-	7:  "is_create_missing_user",
-	8:  "is_force_show_sso_button",
-	9:  "upstream_params",
-	10: "saml_signing_certificate",
-	11: "saml_signing_private_key",
+	2:  "saml_idp_metadata_url",
+	3:  "saml_email_key_attr",
+	4:  "saml_first_name_key_attr",
+	5:  "saml_last_name_key_attr",
+	6:  "is_create_missing_user",
+	7:  "is_force_show_sso_button",
+	8:  "upstream_params",
+	9:  "saml_signing_certificate",
+	10: "saml_signing_private_key",
 }
 
 // Decode decodes UpdateConnectionReqOptions2 from json.
@@ -41870,16 +42153,6 @@ func (s *UpdateConnectionReqOptions2) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"saml_entity_id\"")
-			}
-		case "saml_acs_url":
-			if err := func() error {
-				s.SamlAcsURL.Reset()
-				if err := s.SamlAcsURL.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"saml_acs_url\"")
 			}
 		case "saml_idp_metadata_url":
 			if err := func() error {
@@ -45893,9 +46166,15 @@ func (s *User) encodeFields(e *jx.Encoder) {
 			e.ArrEnd()
 		}
 	}
+	{
+		if s.Billing.Set {
+			e.FieldStart("billing")
+			s.Billing.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfUser = [15]string{
+var jsonFieldsNameOfUser = [16]string{
 	0:  "id",
 	1:  "provided_id",
 	2:  "preferred_email",
@@ -45911,6 +46190,7 @@ var jsonFieldsNameOfUser = [15]string{
 	12: "created_on",
 	13: "organizations",
 	14: "identities",
+	15: "billing",
 }
 
 // Decode decodes User from json.
@@ -46087,6 +46367,16 @@ func (s *User) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"identities\"")
 			}
+		case "billing":
+			if err := func() error {
+				s.Billing.Reset()
+				if err := s.Billing.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"billing\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -46107,6 +46397,69 @@ func (s *User) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *User) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *UserBilling) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *UserBilling) encodeFields(e *jx.Encoder) {
+	{
+		if s.CustomerID.Set {
+			e.FieldStart("customer_id")
+			s.CustomerID.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfUserBilling = [1]string{
+	0: "customer_id",
+}
+
+// Decode decodes UserBilling from json.
+func (s *UserBilling) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode UserBilling to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "customer_id":
+			if err := func() error {
+				s.CustomerID.Reset()
+				if err := s.CustomerID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"customer_id\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode UserBilling")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *UserBilling) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *UserBilling) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -46547,6 +46900,12 @@ func (s *UsersResponseUsersItem) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.LastOrganizationSignIns.Set {
+			e.FieldStart("last_organization_sign_ins")
+			s.LastOrganizationSignIns.Encode(e)
+		}
+	}
+	{
 		if s.Organizations != nil {
 			e.FieldStart("organizations")
 			e.ArrStart()
@@ -46574,7 +46933,7 @@ func (s *UsersResponseUsersItem) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUsersResponseUsersItem = [16]string{
+var jsonFieldsNameOfUsersResponseUsersItem = [17]string{
 	0:  "id",
 	1:  "provided_id",
 	2:  "email",
@@ -46588,9 +46947,10 @@ var jsonFieldsNameOfUsersResponseUsersItem = [16]string{
 	10: "failed_sign_ins",
 	11: "last_signed_in",
 	12: "created_on",
-	13: "organizations",
-	14: "identities",
-	15: "billing",
+	13: "last_organization_sign_ins",
+	14: "organizations",
+	15: "identities",
+	16: "billing",
 }
 
 // Decode decodes UsersResponseUsersItem from json.
@@ -46730,6 +47090,16 @@ func (s *UsersResponseUsersItem) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"created_on\"")
+			}
+		case "last_organization_sign_ins":
+			if err := func() error {
+				s.LastOrganizationSignIns.Reset()
+				if err := s.LastOrganizationSignIns.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"last_organization_sign_ins\"")
 			}
 		case "organizations":
 			if err := func() error {
@@ -46940,6 +47310,86 @@ func (s *UsersResponseUsersItemIdentitiesItem) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *UsersResponseUsersItemIdentitiesItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.OrgCode.Set {
+			e.FieldStart("org_code")
+			s.OrgCode.Encode(e)
+		}
+	}
+	{
+		if s.LastSignedIn.Set {
+			e.FieldStart("last_signed_in")
+			s.LastSignedIn.Encode(e, json.EncodeDateTime)
+		}
+	}
+}
+
+var jsonFieldsNameOfUsersResponseUsersItemLastOrganizationSignInsItem = [2]string{
+	0: "org_code",
+	1: "last_signed_in",
+}
+
+// Decode decodes UsersResponseUsersItemLastOrganizationSignInsItem from json.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode UsersResponseUsersItemLastOrganizationSignInsItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "org_code":
+			if err := func() error {
+				s.OrgCode.Reset()
+				if err := s.OrgCode.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"org_code\"")
+			}
+		case "last_signed_in":
+			if err := func() error {
+				s.LastSignedIn.Reset()
+				if err := s.LastSignedIn.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"last_signed_in\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode UsersResponseUsersItemLastOrganizationSignInsItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/kinde/management_api/oas_operations_gen.go
+++ b/kinde/management_api/oas_operations_gen.go
@@ -35,7 +35,7 @@ const (
 	CreateUserIdentityOperation                     OperationName = "CreateUserIdentity"
 	CreateWebHookOperation                          OperationName = "CreateWebHook"
 	DeleteAPIOperation                              OperationName = "DeleteAPI"
-	DeleteAPIAppliationScopeOperation               OperationName = "DeleteAPIAppliationScope"
+	DeleteAPIApplicationScopeOperation              OperationName = "DeleteAPIApplicationScope"
 	DeleteAPIScopeOperation                         OperationName = "DeleteAPIScope"
 	DeleteApiKeyOperation                           OperationName = "DeleteApiKey"
 	DeleteApplicationOperation                      OperationName = "DeleteApplication"

--- a/kinde/management_api/oas_parameters_gen.go
+++ b/kinde/management_api/oas_parameters_gen.go
@@ -5,6 +5,7 @@ package management_api
 import (
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/go-faster/errors"
 
@@ -1483,8 +1484,8 @@ func decodeDeleteAPIParams(args [1]string, argsEscaped bool, r *http.Request) (p
 	return params, nil
 }
 
-// DeleteAPIAppliationScopeParams is parameters of deleteAPIAppliationScope operation.
-type DeleteAPIAppliationScopeParams struct {
+// DeleteAPIApplicationScopeParams is parameters of deleteAPIApplicationScope operation.
+type DeleteAPIApplicationScopeParams struct {
 	// API ID.
 	APIID string
 	// Application ID.
@@ -1493,7 +1494,7 @@ type DeleteAPIAppliationScopeParams struct {
 	ScopeID string
 }
 
-func unpackDeleteAPIAppliationScopeParams(packed middleware.Parameters) (params DeleteAPIAppliationScopeParams) {
+func unpackDeleteAPIApplicationScopeParams(packed middleware.Parameters) (params DeleteAPIApplicationScopeParams) {
 	{
 		key := middleware.ParameterKey{
 			Name: "api_id",
@@ -1518,7 +1519,7 @@ func unpackDeleteAPIAppliationScopeParams(packed middleware.Parameters) (params 
 	return params
 }
 
-func decodeDeleteAPIAppliationScopeParams(args [3]string, argsEscaped bool, r *http.Request) (params DeleteAPIAppliationScopeParams, _ error) {
+func decodeDeleteAPIApplicationScopeParams(args [3]string, argsEscaped bool, r *http.Request) (params DeleteAPIApplicationScopeParams, _ error) {
 	// Decode path: api_id.
 	if err := func() error {
 		param := args[0]
@@ -10123,10 +10124,13 @@ type GetUsersParams struct {
 	Username OptNilString
 	// Filter the results by phone. The query string should be comma separated and url encoded.
 	Phone OptNilString
-	// Specify additional data to retrieve. Use "organizations" and/or "identities".
+	// Specify additional data to retrieve. Use "organizations", "identities" and/or "billing".
 	Expand OptNilString
 	// Filter the results by if the user has at least one organization assigned.
 	HasOrganization OptNilBool
+	// Filter the results to only include users who have been active since this date. Date should be in
+	// ISO 8601 format.
+	ActiveSince OptNilDateTime
 }
 
 func unpackGetUsersParams(packed middleware.Parameters) (params GetUsersParams) {
@@ -10200,6 +10204,15 @@ func unpackGetUsersParams(packed middleware.Parameters) (params GetUsersParams) 
 		}
 		if v, ok := packed[key]; ok {
 			params.HasOrganization = v.(OptNilBool)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "active_since",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ActiveSince = v.(OptNilDateTime)
 		}
 	}
 	return params
@@ -10531,6 +10544,47 @@ func decodeGetUsersParams(args [0]string, argsEscaped bool, r *http.Request) (pa
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "has_organization",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: active_since.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "active_since",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotActiveSinceVal time.Time
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToDateTime(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotActiveSinceVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.ActiveSince.SetTo(paramsDotActiveSinceVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "active_since",
 			In:   "query",
 			Err:  err,
 		}
@@ -12089,7 +12143,9 @@ type SearchUsersParams struct {
 	// Number of results per page. Defaults to 10 if parameter not sent.
 	PageSize OptNilInt
 	// Search the users by email or name. Use '*' to search all.
-	Query      OptNilString
+	Query OptNilString
+	// Search the users by api scopes.
+	APIScopes  OptNilString
 	Properties OptSearchUsersProperties
 	// The ID of the user to start after.
 	StartingAfter OptNilString
@@ -12116,6 +12172,15 @@ func unpackSearchUsersParams(packed middleware.Parameters) (params SearchUsersPa
 		}
 		if v, ok := packed[key]; ok {
 			params.Query = v.(OptNilString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "api_scopes",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.APIScopes = v.(OptNilString)
 		}
 	}
 	{
@@ -12237,6 +12302,47 @@ func decodeSearchUsersParams(args [0]string, argsEscaped bool, r *http.Request) 
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "query",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: api_scopes.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "api_scopes",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotAPIScopesVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotAPIScopesVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.APIScopes.SetTo(paramsDotAPIScopesVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "api_scopes",
 			In:   "query",
 			Err:  err,
 		}

--- a/kinde/management_api/oas_response_decoders_gen.go
+++ b/kinde/management_api/oas_response_decoders_gen.go
@@ -1009,9 +1009,6 @@ func decodeAddOrganizationUsersResponse(resp *http.Response) (res AddOrganizatio
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
-	case 204:
-		// Code 204.
-		return &AddOrganizationUsersNoContent{}, nil
 	case 400:
 		// Code 400.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
@@ -3605,11 +3602,11 @@ func decodeDeleteAPIResponse(resp *http.Response) (res DeleteAPIRes, _ error) {
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
-func decodeDeleteAPIAppliationScopeResponse(resp *http.Response) (res DeleteAPIAppliationScopeRes, _ error) {
+func decodeDeleteAPIApplicationScopeResponse(resp *http.Response) (res DeleteAPIApplicationScopeRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
 		// Code 200.
-		return &DeleteAPIAppliationScopeOK{}, nil
+		return &DeleteAPIApplicationScopeOK{}, nil
 	case 400:
 		// Code 400.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
@@ -3624,7 +3621,7 @@ func decodeDeleteAPIAppliationScopeResponse(resp *http.Response) (res DeleteAPIA
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response DeleteAPIAppliationScopeBadRequest
+			var response DeleteAPIApplicationScopeBadRequest
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -3659,7 +3656,7 @@ func decodeDeleteAPIAppliationScopeResponse(resp *http.Response) (res DeleteAPIA
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response DeleteAPIAppliationScopeForbidden
+			var response DeleteAPIApplicationScopeForbidden
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -3694,7 +3691,7 @@ func decodeDeleteAPIAppliationScopeResponse(resp *http.Response) (res DeleteAPIA
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response DeleteAPIAppliationScopeTooManyRequests
+			var response DeleteAPIApplicationScopeTooManyRequests
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -13501,6 +13498,15 @@ func decodeGetUsersResponse(resp *http.Response) (res GetUsersRes, _ error) {
 					Err:         err,
 				}
 				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
 			}
 			return &response, nil
 		default:

--- a/kinde/management_api/oas_response_encoders_gen.go
+++ b/kinde/management_api/oas_response_encoders_gen.go
@@ -425,12 +425,6 @@ func encodeAddOrganizationUsersResponse(response AddOrganizationUsersRes, w http
 
 		return nil
 
-	case *AddOrganizationUsersNoContent:
-		w.WriteHeader(204)
-		span.SetStatus(codes.Ok, http.StatusText(204))
-
-		return nil
-
 	case *AddOrganizationUsersBadRequest:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(400)
@@ -1576,15 +1570,15 @@ func encodeDeleteAPIResponse(response DeleteAPIRes, w http.ResponseWriter, span 
 	}
 }
 
-func encodeDeleteAPIAppliationScopeResponse(response DeleteAPIAppliationScopeRes, w http.ResponseWriter, span trace.Span) error {
+func encodeDeleteAPIApplicationScopeResponse(response DeleteAPIApplicationScopeRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
-	case *DeleteAPIAppliationScopeOK:
+	case *DeleteAPIApplicationScopeOK:
 		w.WriteHeader(200)
 		span.SetStatus(codes.Ok, http.StatusText(200))
 
 		return nil
 
-	case *DeleteAPIAppliationScopeBadRequest:
+	case *DeleteAPIApplicationScopeBadRequest:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(400)
 		span.SetStatus(codes.Error, http.StatusText(400))
@@ -1597,7 +1591,7 @@ func encodeDeleteAPIAppliationScopeResponse(response DeleteAPIAppliationScopeRes
 
 		return nil
 
-	case *DeleteAPIAppliationScopeForbidden:
+	case *DeleteAPIApplicationScopeForbidden:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(403)
 		span.SetStatus(codes.Error, http.StatusText(403))
@@ -1610,7 +1604,7 @@ func encodeDeleteAPIAppliationScopeResponse(response DeleteAPIAppliationScopeRes
 
 		return nil
 
-	case *DeleteAPIAppliationScopeTooManyRequests:
+	case *DeleteAPIApplicationScopeTooManyRequests:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(429)
 		span.SetStatus(codes.Error, http.StatusText(429))

--- a/kinde/management_api/oas_router_gen.go
+++ b/kinde/management_api/oas_router_gen.go
@@ -303,7 +303,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 												// Leaf node.
 												switch r.Method {
 												case "DELETE":
-													s.handleDeleteAPIAppliationScopeRequest([3]string{
+													s.handleDeleteAPIApplicationScopeRequest([3]string{
 														args[0],
 														args[1],
 														args[2],
@@ -3441,9 +3441,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 												// Leaf node.
 												switch method {
 												case "DELETE":
-													r.name = DeleteAPIAppliationScopeOperation
+													r.name = DeleteAPIApplicationScopeOperation
 													r.summary = "Delete API application scope"
-													r.operationID = "deleteAPIAppliationScope"
+													r.operationID = "deleteAPIApplicationScope"
 													r.pathPattern = "/api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}"
 													r.args = args
 													r.count = 3

--- a/kinde/management_api/oas_schemas_gen.go
+++ b/kinde/management_api/oas_schemas_gen.go
@@ -296,11 +296,6 @@ type AddOrganizationUsersForbidden ErrorResponse
 
 func (*AddOrganizationUsersForbidden) addOrganizationUsersRes() {}
 
-// AddOrganizationUsersNoContent is response for AddOrganizationUsers operation.
-type AddOrganizationUsersNoContent struct{}
-
-func (*AddOrganizationUsersNoContent) addOrganizationUsersRes() {}
-
 type AddOrganizationUsersReq struct {
 	// Users to be added to the organization.
 	Users []AddOrganizationUsersReqUsersItem `json:"users"`
@@ -881,6 +876,8 @@ func (*CreateApiKeyForbidden) createApiKeyRes() {}
 type CreateApiKeyReq struct {
 	// The name of the API key.
 	Name string `json:"name"`
+	// The entity type that will use this API key.
+	Type CreateApiKeyReqType `json:"type"`
 	// The ID of the API this key is associated with.
 	APIID string `json:"api_id"`
 	// Array of scope IDs to associate with this API key.
@@ -894,6 +891,11 @@ type CreateApiKeyReq struct {
 // GetName returns the value of Name.
 func (s *CreateApiKeyReq) GetName() string {
 	return s.Name
+}
+
+// GetType returns the value of Type.
+func (s *CreateApiKeyReq) GetType() CreateApiKeyReqType {
+	return s.Type
 }
 
 // GetAPIID returns the value of APIID.
@@ -921,6 +923,11 @@ func (s *CreateApiKeyReq) SetName(val string) {
 	s.Name = val
 }
 
+// SetType sets the value of Type.
+func (s *CreateApiKeyReq) SetType(val CreateApiKeyReqType) {
+	s.Type = val
+}
+
 // SetAPIID sets the value of APIID.
 func (s *CreateApiKeyReq) SetAPIID(val string) {
 	s.APIID = val
@@ -939,6 +946,55 @@ func (s *CreateApiKeyReq) SetUserID(val OptNilString) {
 // SetOrgCode sets the value of OrgCode.
 func (s *CreateApiKeyReq) SetOrgCode(val OptNilString) {
 	s.OrgCode = val
+}
+
+// The entity type that will use this API key.
+type CreateApiKeyReqType string
+
+const (
+	CreateApiKeyReqTypeUser         CreateApiKeyReqType = "user"
+	CreateApiKeyReqTypeOrganization CreateApiKeyReqType = "organization"
+	CreateApiKeyReqTypeEnvironment  CreateApiKeyReqType = "environment"
+)
+
+// AllValues returns all CreateApiKeyReqType values.
+func (CreateApiKeyReqType) AllValues() []CreateApiKeyReqType {
+	return []CreateApiKeyReqType{
+		CreateApiKeyReqTypeUser,
+		CreateApiKeyReqTypeOrganization,
+		CreateApiKeyReqTypeEnvironment,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s CreateApiKeyReqType) MarshalText() ([]byte, error) {
+	switch s {
+	case CreateApiKeyReqTypeUser:
+		return []byte(s), nil
+	case CreateApiKeyReqTypeOrganization:
+		return []byte(s), nil
+	case CreateApiKeyReqTypeEnvironment:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *CreateApiKeyReqType) UnmarshalText(data []byte) error {
+	switch CreateApiKeyReqType(data) {
+	case CreateApiKeyReqTypeUser:
+		*s = CreateApiKeyReqTypeUser
+		return nil
+	case CreateApiKeyReqTypeOrganization:
+		*s = CreateApiKeyReqTypeOrganization
+		return nil
+	case CreateApiKeyReqTypeEnvironment:
+		*s = CreateApiKeyReqTypeEnvironment
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 type CreateApiKeyTooManyRequests ErrorResponse
@@ -1777,8 +1833,6 @@ type CreateConnectionReqOptions2 struct {
 	HomeRealmDomains []string `json:"home_realm_domains"`
 	// SAML Entity ID.
 	SamlEntityID OptString `json:"saml_entity_id"`
-	// Assertion Consumer Service URL.
-	SamlAcsURL OptString `json:"saml_acs_url"`
 	// URL for the IdP metadata.
 	SamlIdpMetadataURL OptString `json:"saml_idp_metadata_url"`
 	// Override the default SSO endpoint with a URL your IdP recognizes.
@@ -1811,11 +1865,6 @@ func (s *CreateConnectionReqOptions2) GetHomeRealmDomains() []string {
 // GetSamlEntityID returns the value of SamlEntityID.
 func (s *CreateConnectionReqOptions2) GetSamlEntityID() OptString {
 	return s.SamlEntityID
-}
-
-// GetSamlAcsURL returns the value of SamlAcsURL.
-func (s *CreateConnectionReqOptions2) GetSamlAcsURL() OptString {
-	return s.SamlAcsURL
 }
 
 // GetSamlIdpMetadataURL returns the value of SamlIdpMetadataURL.
@@ -1881,11 +1930,6 @@ func (s *CreateConnectionReqOptions2) SetHomeRealmDomains(val []string) {
 // SetSamlEntityID sets the value of SamlEntityID.
 func (s *CreateConnectionReqOptions2) SetSamlEntityID(val OptString) {
 	s.SamlEntityID = val
-}
-
-// SetSamlAcsURL sets the value of SamlAcsURL.
-func (s *CreateConnectionReqOptions2) SetSamlAcsURL(val OptString) {
-	s.SamlAcsURL = val
 }
 
 // SetSamlIdpMetadataURL sets the value of SamlIdpMetadataURL.
@@ -1976,6 +2020,10 @@ const (
 	CreateConnectionReqStrategyOAuth2Twitter   CreateConnectionReqStrategy = "oauth2:twitter"
 	CreateConnectionReqStrategyOAuth2Xero      CreateConnectionReqStrategy = "oauth2:xero"
 	CreateConnectionReqStrategySamlCustom      CreateConnectionReqStrategy = "saml:custom"
+	CreateConnectionReqStrategySamlCloudflare  CreateConnectionReqStrategy = "saml:cloudflare"
+	CreateConnectionReqStrategySamlOkta        CreateConnectionReqStrategy = "saml:okta"
+	CreateConnectionReqStrategySamlMicrosoft   CreateConnectionReqStrategy = "saml:microsoft"
+	CreateConnectionReqStrategySamlGoogle      CreateConnectionReqStrategy = "saml:google"
 	CreateConnectionReqStrategyWsfedAzureAd    CreateConnectionReqStrategy = "wsfed:azure_ad"
 )
 
@@ -1999,6 +2047,10 @@ func (CreateConnectionReqStrategy) AllValues() []CreateConnectionReqStrategy {
 		CreateConnectionReqStrategyOAuth2Twitter,
 		CreateConnectionReqStrategyOAuth2Xero,
 		CreateConnectionReqStrategySamlCustom,
+		CreateConnectionReqStrategySamlCloudflare,
+		CreateConnectionReqStrategySamlOkta,
+		CreateConnectionReqStrategySamlMicrosoft,
+		CreateConnectionReqStrategySamlGoogle,
 		CreateConnectionReqStrategyWsfedAzureAd,
 	}
 }
@@ -2039,6 +2091,14 @@ func (s CreateConnectionReqStrategy) MarshalText() ([]byte, error) {
 	case CreateConnectionReqStrategyOAuth2Xero:
 		return []byte(s), nil
 	case CreateConnectionReqStrategySamlCustom:
+		return []byte(s), nil
+	case CreateConnectionReqStrategySamlCloudflare:
+		return []byte(s), nil
+	case CreateConnectionReqStrategySamlOkta:
+		return []byte(s), nil
+	case CreateConnectionReqStrategySamlMicrosoft:
+		return []byte(s), nil
+	case CreateConnectionReqStrategySamlGoogle:
 		return []byte(s), nil
 	case CreateConnectionReqStrategyWsfedAzureAd:
 		return []byte(s), nil
@@ -2100,6 +2160,18 @@ func (s *CreateConnectionReqStrategy) UnmarshalText(data []byte) error {
 		return nil
 	case CreateConnectionReqStrategySamlCustom:
 		*s = CreateConnectionReqStrategySamlCustom
+		return nil
+	case CreateConnectionReqStrategySamlCloudflare:
+		*s = CreateConnectionReqStrategySamlCloudflare
+		return nil
+	case CreateConnectionReqStrategySamlOkta:
+		*s = CreateConnectionReqStrategySamlOkta
+		return nil
+	case CreateConnectionReqStrategySamlMicrosoft:
+		*s = CreateConnectionReqStrategySamlMicrosoft
+		return nil
+	case CreateConnectionReqStrategySamlGoogle:
+		*s = CreateConnectionReqStrategySamlGoogle
 		return nil
 	case CreateConnectionReqStrategyWsfedAzureAd:
 		*s = CreateConnectionReqStrategyWsfedAzureAd
@@ -2500,6 +2572,8 @@ func (*CreateIdentityResponse) createUserIdentityRes() {}
 type CreateIdentityResponseIdentity struct {
 	// The identity's ID.
 	ID OptString `json:"id"`
+	// The identity's ID (returned when creating with existing enterprise identity).
+	IdentityID OptString `json:"identity_id"`
 }
 
 // GetID returns the value of ID.
@@ -2507,9 +2581,19 @@ func (s *CreateIdentityResponseIdentity) GetID() OptString {
 	return s.ID
 }
 
+// GetIdentityID returns the value of IdentityID.
+func (s *CreateIdentityResponseIdentity) GetIdentityID() OptString {
+	return s.IdentityID
+}
+
 // SetID sets the value of ID.
 func (s *CreateIdentityResponseIdentity) SetID(val OptString) {
 	s.ID = val
+}
+
+// SetIdentityID sets the value of IdentityID.
+func (s *CreateIdentityResponseIdentity) SetIdentityID(val OptString) {
+	s.IdentityID = val
 }
 
 type CreateMeterUsageRecordBadRequest ErrorResponse
@@ -4093,22 +4177,22 @@ func (s *CreateWebhookResponseWebhook) SetEndpoint(val OptString) {
 	s.Endpoint = val
 }
 
-type DeleteAPIAppliationScopeBadRequest ErrorResponse
+type DeleteAPIApplicationScopeBadRequest ErrorResponse
 
-func (*DeleteAPIAppliationScopeBadRequest) deleteAPIAppliationScopeRes() {}
+func (*DeleteAPIApplicationScopeBadRequest) deleteAPIApplicationScopeRes() {}
 
-type DeleteAPIAppliationScopeForbidden ErrorResponse
+type DeleteAPIApplicationScopeForbidden ErrorResponse
 
-func (*DeleteAPIAppliationScopeForbidden) deleteAPIAppliationScopeRes() {}
+func (*DeleteAPIApplicationScopeForbidden) deleteAPIApplicationScopeRes() {}
 
-// DeleteAPIAppliationScopeOK is response for DeleteAPIAppliationScope operation.
-type DeleteAPIAppliationScopeOK struct{}
+// DeleteAPIApplicationScopeOK is response for DeleteAPIApplicationScope operation.
+type DeleteAPIApplicationScopeOK struct{}
 
-func (*DeleteAPIAppliationScopeOK) deleteAPIAppliationScopeRes() {}
+func (*DeleteAPIApplicationScopeOK) deleteAPIApplicationScopeRes() {}
 
-type DeleteAPIAppliationScopeTooManyRequests ErrorResponse
+type DeleteAPIApplicationScopeTooManyRequests ErrorResponse
 
-func (*DeleteAPIAppliationScopeTooManyRequests) deleteAPIAppliationScopeRes() {}
+func (*DeleteAPIApplicationScopeTooManyRequests) deleteAPIApplicationScopeRes() {}
 
 type DeleteAPIBadRequest ErrorResponse
 
@@ -8748,7 +8832,9 @@ type GetOrganizationResponse struct {
 	// The organization's SVG favicon URL. Optimal format for most browsers.
 	FaviconSvg OptNilString `json:"favicon_svg"`
 	// The favicon URL to be used as a fallback in browsers that don't support SVG, add a PNG.
-	FaviconFallback     OptNilString                                     `json:"favicon_fallback"`
+	FaviconFallback OptNilString `json:"favicon_fallback"`
+	// Domains allowed for self-sign up to this environment.  Empty array means no restrictions.
+	AllowedDomains      []string                                         `json:"allowed_domains"`
 	LinkColor           OptNilGetOrganizationResponseLinkColor           `json:"link_color"`
 	BackgroundColor     OptNilGetOrganizationResponseBackgroundColor     `json:"background_color"`
 	ButtonColor         OptNilGetOrganizationResponseButtonColor         `json:"button_color"`
@@ -8829,6 +8915,11 @@ func (s *GetOrganizationResponse) GetFaviconSvg() OptNilString {
 // GetFaviconFallback returns the value of FaviconFallback.
 func (s *GetOrganizationResponse) GetFaviconFallback() OptNilString {
 	return s.FaviconFallback
+}
+
+// GetAllowedDomains returns the value of AllowedDomains.
+func (s *GetOrganizationResponse) GetAllowedDomains() []string {
+	return s.AllowedDomains
 }
 
 // GetLinkColor returns the value of LinkColor.
@@ -8969,6 +9060,11 @@ func (s *GetOrganizationResponse) SetFaviconSvg(val OptNilString) {
 // SetFaviconFallback sets the value of FaviconFallback.
 func (s *GetOrganizationResponse) SetFaviconFallback(val OptNilString) {
 	s.FaviconFallback = val
+}
+
+// SetAllowedDomains sets the value of AllowedDomains.
+func (s *GetOrganizationResponse) SetAllowedDomains(val []string) {
+	s.AllowedDomains = val
 }
 
 // SetLinkColor sets the value of LinkColor.
@@ -16194,6 +16290,69 @@ func (o OptNilUpdateOrganizationExpand) Or(d UpdateOrganizationExpand) UpdateOrg
 	return d
 }
 
+// NewOptNilUsersResponseUsersItemLastOrganizationSignInsItemArray returns new OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray with value set to v.
+func NewOptNilUsersResponseUsersItemLastOrganizationSignInsItemArray(v []UsersResponseUsersItemLastOrganizationSignInsItem) OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray {
+	return OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray is optional nullable []UsersResponseUsersItemLastOrganizationSignInsItem.
+type OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray struct {
+	Value []UsersResponseUsersItemLastOrganizationSignInsItem
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray was set.
+func (o OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) Reset() {
+	var v []UsersResponseUsersItemLastOrganizationSignInsItem
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) SetTo(v []UsersResponseUsersItemLastOrganizationSignInsItem) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v []UsersResponseUsersItemLastOrganizationSignInsItem
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) Get() (v []UsersResponseUsersItemLastOrganizationSignInsItem, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) Or(d []UsersResponseUsersItemLastOrganizationSignInsItem) []UsersResponseUsersItemLastOrganizationSignInsItem {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptNotFoundResponseErrors returns new OptNotFoundResponseErrors with value set to v.
 func NewOptNotFoundResponseErrors(v NotFoundResponseErrors) OptNotFoundResponseErrors {
 	return OptNotFoundResponseErrors{
@@ -17160,6 +17319,52 @@ func (o OptUpdateWebhookResponseWebhook) Or(d UpdateWebhookResponseWebhook) Upda
 	return d
 }
 
+// NewOptUserBilling returns new OptUserBilling with value set to v.
+func NewOptUserBilling(v UserBilling) OptUserBilling {
+	return OptUserBilling{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptUserBilling is optional UserBilling.
+type OptUserBilling struct {
+	Value UserBilling
+	Set   bool
+}
+
+// IsSet returns true if OptUserBilling was set.
+func (o OptUserBilling) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptUserBilling) Reset() {
+	var v UserBilling
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptUserBilling) SetTo(v UserBilling) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptUserBilling) Get() (v UserBilling, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptUserBilling) Or(d UserBilling) UserBilling {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptUserIdentityResult returns new OptUserIdentityResult with value set to v.
 func NewOptUserIdentityResult(v UserIdentityResult) OptUserIdentityResult {
 	return OptUserIdentityResult{
@@ -17347,6 +17552,8 @@ type OrganizationUser struct {
 	JoinedOn OptString `json:"joined_on"`
 	// The date the user last accessed the organization.
 	LastAccessedOn OptNilString `json:"last_accessed_on"`
+	// Whether the user is currently suspended or not.
+	IsSuspended OptBool `json:"is_suspended"`
 	// The roles the user has in the organization.
 	Roles []string `json:"roles"`
 }
@@ -17389,6 +17596,11 @@ func (s *OrganizationUser) GetJoinedOn() OptString {
 // GetLastAccessedOn returns the value of LastAccessedOn.
 func (s *OrganizationUser) GetLastAccessedOn() OptNilString {
 	return s.LastAccessedOn
+}
+
+// GetIsSuspended returns the value of IsSuspended.
+func (s *OrganizationUser) GetIsSuspended() OptBool {
+	return s.IsSuspended
 }
 
 // GetRoles returns the value of Roles.
@@ -17434,6 +17646,11 @@ func (s *OrganizationUser) SetJoinedOn(val OptString) {
 // SetLastAccessedOn sets the value of LastAccessedOn.
 func (s *OrganizationUser) SetLastAccessedOn(val OptNilString) {
 	s.LastAccessedOn = val
+}
+
+// SetIsSuspended sets the value of IsSuspended.
+func (s *OrganizationUser) SetIsSuspended(val OptBool) {
+	s.IsSuspended = val
 }
 
 // SetRoles sets the value of Roles.
@@ -18340,8 +18557,6 @@ type ReplaceConnectionReqOptions2 struct {
 	HomeRealmDomains []string `json:"home_realm_domains"`
 	// SAML Entity ID.
 	SamlEntityID OptString `json:"saml_entity_id"`
-	// Assertion Consumer Service URL.
-	SamlAcsURL OptString `json:"saml_acs_url"`
 	// URL for the IdP metadata.
 	SamlIdpMetadataURL OptString `json:"saml_idp_metadata_url"`
 	// Attribute key for the user’s email.
@@ -18370,11 +18585,6 @@ func (s *ReplaceConnectionReqOptions2) GetHomeRealmDomains() []string {
 // GetSamlEntityID returns the value of SamlEntityID.
 func (s *ReplaceConnectionReqOptions2) GetSamlEntityID() OptString {
 	return s.SamlEntityID
-}
-
-// GetSamlAcsURL returns the value of SamlAcsURL.
-func (s *ReplaceConnectionReqOptions2) GetSamlAcsURL() OptString {
-	return s.SamlAcsURL
 }
 
 // GetSamlIdpMetadataURL returns the value of SamlIdpMetadataURL.
@@ -18430,11 +18640,6 @@ func (s *ReplaceConnectionReqOptions2) SetHomeRealmDomains(val []string) {
 // SetSamlEntityID sets the value of SamlEntityID.
 func (s *ReplaceConnectionReqOptions2) SetSamlEntityID(val OptString) {
 	s.SamlEntityID = val
-}
-
-// SetSamlAcsURL sets the value of SamlAcsURL.
-func (s *ReplaceConnectionReqOptions2) SetSamlAcsURL(val OptString) {
-	s.SamlAcsURL = val
 }
 
 // SetSamlIdpMetadataURL sets the value of SamlIdpMetadataURL.
@@ -19208,6 +19413,8 @@ type SearchUsersResponseResultsItem struct {
 	Identities []SearchUsersResponseResultsItemIdentitiesItem `json:"identities"`
 	// The user properties.
 	Properties OptSearchUsersResponseResultsItemProperties `json:"properties"`
+	// Array of api scopes belonging to the user.
+	APIScopes []SearchUsersResponseResultsItemAPIScopesItem `json:"api_scopes"`
 }
 
 // GetID returns the value of ID.
@@ -19285,6 +19492,11 @@ func (s *SearchUsersResponseResultsItem) GetProperties() OptSearchUsersResponseR
 	return s.Properties
 }
 
+// GetAPIScopes returns the value of APIScopes.
+func (s *SearchUsersResponseResultsItem) GetAPIScopes() []SearchUsersResponseResultsItemAPIScopesItem {
+	return s.APIScopes
+}
+
 // SetID sets the value of ID.
 func (s *SearchUsersResponseResultsItem) SetID(val OptString) {
 	s.ID = val
@@ -19358,6 +19570,47 @@ func (s *SearchUsersResponseResultsItem) SetIdentities(val []SearchUsersResponse
 // SetProperties sets the value of Properties.
 func (s *SearchUsersResponseResultsItem) SetProperties(val OptSearchUsersResponseResultsItemProperties) {
 	s.Properties = val
+}
+
+// SetAPIScopes sets the value of APIScopes.
+func (s *SearchUsersResponseResultsItem) SetAPIScopes(val []SearchUsersResponseResultsItemAPIScopesItem) {
+	s.APIScopes = val
+}
+
+type SearchUsersResponseResultsItemAPIScopesItem struct {
+	OrgCode OptString `json:"org_code"`
+	Scope   OptString `json:"scope"`
+	APIID   OptString `json:"api_id"`
+}
+
+// GetOrgCode returns the value of OrgCode.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) GetOrgCode() OptString {
+	return s.OrgCode
+}
+
+// GetScope returns the value of Scope.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) GetScope() OptString {
+	return s.Scope
+}
+
+// GetAPIID returns the value of APIID.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) GetAPIID() OptString {
+	return s.APIID
+}
+
+// SetOrgCode sets the value of OrgCode.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) SetOrgCode(val OptString) {
+	s.OrgCode = val
+}
+
+// SetScope sets the value of Scope.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) SetScope(val OptString) {
+	s.Scope = val
+}
+
+// SetAPIID sets the value of APIID.
+func (s *SearchUsersResponseResultsItemAPIScopesItem) SetAPIID(val OptString) {
+	s.APIID = val
 }
 
 type SearchUsersResponseResultsItemIdentitiesItem struct {
@@ -20629,8 +20882,6 @@ type UpdateConnectionReqOptions2 struct {
 	HomeRealmDomains []string `json:"home_realm_domains"`
 	// SAML Entity ID.
 	SamlEntityID OptString `json:"saml_entity_id"`
-	// Assertion Consumer Service URL.
-	SamlAcsURL OptString `json:"saml_acs_url"`
 	// URL for the IdP metadata.
 	SamlIdpMetadataURL OptString `json:"saml_idp_metadata_url"`
 	// Attribute key for the user’s email.
@@ -20659,11 +20910,6 @@ func (s *UpdateConnectionReqOptions2) GetHomeRealmDomains() []string {
 // GetSamlEntityID returns the value of SamlEntityID.
 func (s *UpdateConnectionReqOptions2) GetSamlEntityID() OptString {
 	return s.SamlEntityID
-}
-
-// GetSamlAcsURL returns the value of SamlAcsURL.
-func (s *UpdateConnectionReqOptions2) GetSamlAcsURL() OptString {
-	return s.SamlAcsURL
 }
 
 // GetSamlIdpMetadataURL returns the value of SamlIdpMetadataURL.
@@ -20719,11 +20965,6 @@ func (s *UpdateConnectionReqOptions2) SetHomeRealmDomains(val []string) {
 // SetSamlEntityID sets the value of SamlEntityID.
 func (s *UpdateConnectionReqOptions2) SetSamlEntityID(val OptString) {
 	s.SamlEntityID = val
-}
-
-// SetSamlAcsURL sets the value of SamlAcsURL.
-func (s *UpdateConnectionReqOptions2) SetSamlAcsURL(val OptString) {
-	s.SamlAcsURL = val
 }
 
 // SetSamlIdpMetadataURL sets the value of SamlIdpMetadataURL.
@@ -21456,7 +21697,7 @@ type UpdateOrganizationSessionsReqSSOSessionPersistenceMode string
 
 const (
 	UpdateOrganizationSessionsReqSSOSessionPersistenceModePersistent    UpdateOrganizationSessionsReqSSOSessionPersistenceMode = "persistent"
-	UpdateOrganizationSessionsReqSSOSessionPersistenceModeNonPersistent UpdateOrganizationSessionsReqSSOSessionPersistenceMode = "non-persistent"
+	UpdateOrganizationSessionsReqSSOSessionPersistenceModeNonPersistent UpdateOrganizationSessionsReqSSOSessionPersistenceMode = "non_persistent"
 )
 
 // AllValues returns all UpdateOrganizationSessionsReqSSOSessionPersistenceMode values.
@@ -21867,8 +22108,8 @@ type UpdateRolesReq struct {
 	Key string `json:"key"`
 	// Set role as default for new users.
 	IsDefaultRole OptBool `json:"is_default_role"`
-	// The public ID of the permission required to assign this role to users. If null, no permission is
-	// required.
+	// The public ID of the permission required to assign this role to users. If null, no change to the
+	// assignment permission is made. If set to 'NO_PERMISSION_REQUIRED', no permission is required.
 	AssignmentPermissionID OptNilUUID `json:"assignment_permission_id"`
 }
 
@@ -22288,6 +22529,7 @@ type User struct {
 	Organizations []string `json:"organizations"`
 	// Array of identities belonging to the user.
 	Identities []UserIdentitiesItem `json:"identities"`
+	Billing    OptUserBilling       `json:"billing"`
 }
 
 // GetID returns the value of ID.
@@ -22365,6 +22607,11 @@ func (s *User) GetIdentities() []UserIdentitiesItem {
 	return s.Identities
 }
 
+// GetBilling returns the value of Billing.
+func (s *User) GetBilling() OptUserBilling {
+	return s.Billing
+}
+
 // SetID sets the value of ID.
 func (s *User) SetID(val OptString) {
 	s.ID = val
@@ -22440,7 +22687,26 @@ func (s *User) SetIdentities(val []UserIdentitiesItem) {
 	s.Identities = val
 }
 
+// SetBilling sets the value of Billing.
+func (s *User) SetBilling(val OptUserBilling) {
+	s.Billing = val
+}
+
 func (*User) getUserDataRes() {}
+
+type UserBilling struct {
+	CustomerID OptString `json:"customer_id"`
+}
+
+// GetCustomerID returns the value of CustomerID.
+func (s *UserBilling) GetCustomerID() OptString {
+	return s.CustomerID
+}
+
+// SetCustomerID sets the value of CustomerID.
+func (s *UserBilling) SetCustomerID(val OptString) {
+	s.CustomerID = val
+}
 
 type UserIdentitiesItem struct {
 	Type     OptString `json:"type"`
@@ -22591,6 +22857,8 @@ type UsersResponseUsersItem struct {
 	LastSignedIn OptNilString `json:"last_signed_in"`
 	// Date of user creation in ISO 8601 format.
 	CreatedOn OptNilString `json:"created_on"`
+	// Array of organization sign-in information for the user.
+	LastOrganizationSignIns OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray `json:"last_organization_sign_ins"`
 	// Array of organizations a user belongs to.
 	Organizations []string `json:"organizations"`
 	// Array of identities belonging to the user.
@@ -22661,6 +22929,11 @@ func (s *UsersResponseUsersItem) GetLastSignedIn() OptNilString {
 // GetCreatedOn returns the value of CreatedOn.
 func (s *UsersResponseUsersItem) GetCreatedOn() OptNilString {
 	return s.CreatedOn
+}
+
+// GetLastOrganizationSignIns returns the value of LastOrganizationSignIns.
+func (s *UsersResponseUsersItem) GetLastOrganizationSignIns() OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray {
+	return s.LastOrganizationSignIns
 }
 
 // GetOrganizations returns the value of Organizations.
@@ -22743,6 +23016,11 @@ func (s *UsersResponseUsersItem) SetCreatedOn(val OptNilString) {
 	s.CreatedOn = val
 }
 
+// SetLastOrganizationSignIns sets the value of LastOrganizationSignIns.
+func (s *UsersResponseUsersItem) SetLastOrganizationSignIns(val OptNilUsersResponseUsersItemLastOrganizationSignInsItemArray) {
+	s.LastOrganizationSignIns = val
+}
+
 // SetOrganizations sets the value of Organizations.
 func (s *UsersResponseUsersItem) SetOrganizations(val []string) {
 	s.Organizations = val
@@ -22796,6 +23074,33 @@ func (s *UsersResponseUsersItemIdentitiesItem) SetType(val OptString) {
 // SetIdentity sets the value of Identity.
 func (s *UsersResponseUsersItemIdentitiesItem) SetIdentity(val OptString) {
 	s.Identity = val
+}
+
+type UsersResponseUsersItemLastOrganizationSignInsItem struct {
+	// The organization code.
+	OrgCode OptString `json:"org_code"`
+	// The date and time the user last signed in to this organization in ISO 8601 format.
+	LastSignedIn OptDateTime `json:"last_signed_in"`
+}
+
+// GetOrgCode returns the value of OrgCode.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) GetOrgCode() OptString {
+	return s.OrgCode
+}
+
+// GetLastSignedIn returns the value of LastSignedIn.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) GetLastSignedIn() OptDateTime {
+	return s.LastSignedIn
+}
+
+// SetOrgCode sets the value of OrgCode.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) SetOrgCode(val OptString) {
+	s.OrgCode = val
+}
+
+// SetLastSignedIn sets the value of LastSignedIn.
+func (s *UsersResponseUsersItemLastOrganizationSignInsItem) SetLastSignedIn(val OptDateTime) {
+	s.LastSignedIn = val
 }
 
 // Ref: #/components/schemas/verify_api_key_response

--- a/kinde/management_api/oas_security_gen.go
+++ b/kinde/management_api/oas_security_gen.go
@@ -64,7 +64,7 @@ var operationRolesKindeBearerAuth = map[string][]string{
 	CreateUserIdentityOperation:                     []string{},
 	CreateWebHookOperation:                          []string{},
 	DeleteAPIOperation:                              []string{},
-	DeleteAPIAppliationScopeOperation:               []string{},
+	DeleteAPIApplicationScopeOperation:              []string{},
 	DeleteAPIScopeOperation:                         []string{},
 	DeleteApiKeyOperation:                           []string{},
 	DeleteApplicationOperation:                      []string{},

--- a/kinde/management_api/oas_server_gen.go
+++ b/kinde/management_api/oas_server_gen.go
@@ -274,7 +274,7 @@ type Handler interface {
 	//
 	// DELETE /api/v1/apis/{api_id}
 	DeleteAPI(ctx context.Context, params DeleteAPIParams) (DeleteAPIRes, error)
-	// DeleteAPIAppliationScope implements deleteAPIAppliationScope operation.
+	// DeleteAPIApplicationScope implements deleteAPIApplicationScope operation.
 	//
 	// Delete an API application scope you previously created.
 	// <div>
@@ -282,7 +282,7 @@ type Handler interface {
 	// </div>.
 	//
 	// DELETE /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}
-	DeleteAPIAppliationScope(ctx context.Context, params DeleteAPIAppliationScopeParams) (DeleteAPIAppliationScopeRes, error)
+	DeleteAPIApplicationScope(ctx context.Context, params DeleteAPIApplicationScopeParams) (DeleteAPIApplicationScopeRes, error)
 	// DeleteAPIScope implements deleteAPIScope operation.
 	//
 	// Delete an API scope you previously created.

--- a/kinde/management_api/oas_unimplemented_gen.go
+++ b/kinde/management_api/oas_unimplemented_gen.go
@@ -366,7 +366,7 @@ func (UnimplementedHandler) DeleteAPI(ctx context.Context, params DeleteAPIParam
 	return r, ht.ErrNotImplemented
 }
 
-// DeleteAPIAppliationScope implements deleteAPIAppliationScope operation.
+// DeleteAPIApplicationScope implements deleteAPIApplicationScope operation.
 //
 // Delete an API application scope you previously created.
 // <div>
@@ -374,7 +374,7 @@ func (UnimplementedHandler) DeleteAPI(ctx context.Context, params DeleteAPIParam
 // </div>.
 //
 // DELETE /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}
-func (UnimplementedHandler) DeleteAPIAppliationScope(ctx context.Context, params DeleteAPIAppliationScopeParams) (r DeleteAPIAppliationScopeRes, _ error) {
+func (UnimplementedHandler) DeleteAPIApplicationScope(ctx context.Context, params DeleteAPIApplicationScopeParams) (r DeleteAPIApplicationScopeRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/kinde/management_api/oas_validators_gen.go
+++ b/kinde/management_api/oas_validators_gen.go
@@ -39,6 +39,17 @@ func (s *CreateApiKeyReq) Validate() error {
 
 	var failures []validate.FieldError
 	if err := func() error {
+		if err := s.Type.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "type",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if value, ok := s.ScopeIds.Get(); ok {
 			if err := func() error {
 				if value == nil {
@@ -60,6 +71,19 @@ func (s *CreateApiKeyReq) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s CreateApiKeyReqType) Validate() error {
+	switch s {
+	case "user":
+		return nil
+	case "organization":
+		return nil
+	case "environment":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *CreateApplicationReq) Validate() error {
@@ -201,6 +225,14 @@ func (s CreateConnectionReqStrategy) Validate() error {
 	case "oauth2:xero":
 		return nil
 	case "saml:custom":
+		return nil
+	case "saml:cloudflare":
+		return nil
+	case "saml:okta":
+		return nil
+	case "saml:microsoft":
+		return nil
+	case "saml:google":
 		return nil
 	case "wsfed:azure_ad":
 		return nil
@@ -1695,9 +1727,76 @@ func (s UpdateOrganizationSessionsReqSSOSessionPersistenceMode) Validate() error
 	switch s {
 	case "persistent":
 		return nil
-	case "non-persistent":
+	case "non_persistent":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
+}
+
+func (s *UsersResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Users {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "users",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *UsersResponseUsersItem) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.LastOrganizationSignIns.Get(); ok {
+			if err := func() error {
+				if value == nil {
+					return errors.New("nil is invalid value")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "last_organization_sign_ins",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
 }

--- a/kinde/management_api/spec/kinde-management-api-spec.yaml
+++ b/kinde/management_api/spec/kinde-management-api-spec.yaml
@@ -1,0 +1,11916 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: Kinde Management API
+  description: |
+
+    Provides endpoints to manage your Kinde Businesses.
+
+    ## Intro
+
+    ## How to use
+
+    1. [Set up and authorize a machine-to-machine (M2M) application](https://docs.kinde.com/developer-tools/kinde-api/connect-to-kinde-api/).
+
+    2. [Generate a test access token](https://docs.kinde.com/developer-tools/kinde-api/access-token-for-api/)
+
+    3. Test request any endpoint using the test token
+  termsOfService: https://docs.kinde.com/trust-center/agreements/terms-of-service/
+  contact:
+    name: Kinde Support Team
+    email: support@kinde.com
+    url: https://docs.kinde.com
+servers:
+  - url: https://{subdomain}.kinde.com
+    variables:
+      subdomain:
+        default: your_kinde_subdomain
+        description: The subdomain generated for your business on Kinde.
+tags:
+  - name: API Keys
+    x-displayName: API Keys
+  - name: APIs
+    x-displayName: APIs
+  - name: Applications
+    x-displayName: Applications
+  - name: Billing Entitlements
+    x-displayName: Billing Entitlements
+  - name: Billing Agreements
+    x-displayName: Billing Agreements
+  - name: Billing Meter Usage
+    x-displayName: Billing Meter Usage
+  - name: Business
+    x-displayName: Business
+  - name: Industries
+    x-displayName: Industries
+  - name: Timezones
+    x-displayName: Timezones
+  - name: Callbacks
+    x-displayName: Callbacks
+  - name: Connected Apps
+    x-displayName: Connected Apps
+  - name: Connections
+    x-displayName: Connections
+  - name: Environments
+    x-displayName: Environments
+  - name: Environment variables
+    x-displayName: Environment variables
+  - name: Feature Flags
+    x-displayName: Feature Flags
+  - name: Identities
+    x-displayName: Identities
+  - name: MFA
+    x-displayName: MFA
+  - name: Organizations
+    x-displayName: Organizations
+  - name: Permissions
+    x-displayName: Permissions
+  - name: Properties
+    x-displayName: Properties
+  - name: Property Categories
+    x-displayName: Property Categories
+  - name: Roles
+    x-displayName: Roles
+  - name: Search
+    x-displayName: Search
+  - name: Subscribers
+    x-displayName: Subscribers
+  - name: Users
+    x-displayName: Users
+  - name: Webhooks
+    x-displayName: Webhooks
+paths:
+  /api/v1/api_keys:
+    servers: []
+    get:
+      tags:
+        - API Keys
+      operationId: getApiKeys
+      x-scope: read:api_keys
+      summary: Get API keys
+      description: |
+        Returns a list of API keys.
+
+        <div>
+          <code>read:api_keys</code>
+        </div>
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 50 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the API key to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: key_type
+          in: query
+          description: Filter by API key type (organization or user).
+          schema:
+            type: string
+            enum:
+              - organization
+              - user
+            nullable: true
+        - name: status
+          in: query
+          description: Filter by API key status (active, inactive, revoked).
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+              - revoked
+            nullable: true
+        - name: user_id
+          in: query
+          description: Filter by user ID to get API keys associated with a specific user.
+          schema:
+            type: string
+            nullable: true
+        - name: org_code
+          in: query
+          description: Filter by organization code to get API keys associated with a specific organization.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: API keys successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_keys_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - API Keys
+      operationId: createApiKey
+      x-scope: create:api_keys
+      summary: Create API key
+      description: |
+        Create a new API key.
+
+        <div>
+          <code>create:api_keys</code>
+        </div>
+      requestBody:
+        description: API key details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the API key.
+                  type: string
+                  nullable: false
+                type:
+                  description: The entity type that will use this API key.
+                  type: string
+                  enum:
+                    - user
+                    - organization
+                    - environment
+                  nullable: false
+                api_id:
+                  description: The ID of the API this key is associated with.
+                  type: string
+                  nullable: false
+                scope_ids:
+                  description: Array of scope IDs to associate with this API key.
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
+                user_id:
+                  description: The ID of the user to associate with this API key (for user-level keys).
+                  type: string
+                  nullable: true
+                org_code:
+                  description: The organization code to associate with this API key (for organization-level keys).
+                  type: string
+                  nullable: true
+              required:
+                - name
+                - api_id
+                - type
+      responses:
+        '201':
+          description: API key successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_api_key_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/api_keys/{key_id}:
+    servers: []
+    get:
+      tags:
+        - API Keys
+      operationId: getApiKey
+      x-scope: read:api_keys
+      summary: Get API key
+      description: |
+        Retrieve API key details by ID.
+
+        <div>
+          <code>read:api_keys</code>
+        </div>
+      parameters:
+        - name: key_id
+          in: path
+          description: The ID of the API key.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: API key successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_key_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - API Keys
+      operationId: deleteApiKey
+      x-scope: delete:api_keys
+      summary: Delete API key
+      description: |
+        Delete an API key.
+
+        <div>
+          <code>delete:api_keys</code>
+        </div>
+      parameters:
+        - name: key_id
+          in: path
+          description: The ID of the API key.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: API key successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - API Keys
+      operationId: rotateApiKey
+      x-scope: update:api_keys
+      summary: Rotate API key
+      description: |
+        Rotate an API key to generate a new key while maintaining the same permissions and associations.
+
+        <div>
+          <code>update:api_keys</code>
+        </div>
+      parameters:
+        - name: key_id
+          in: path
+          description: The ID of the API key to rotate.
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: API key successfully rotated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rotate_api_key_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/api_keys/verify:
+    servers: []
+    post:
+      tags:
+        - API Keys
+      operationId: verifyApiKey
+      summary: Verify API key
+      description: |
+        Verify an API key (public endpoint, no authentication required).
+      requestBody:
+        description: API key verification details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                api_key:
+                  description: The API key to verify.
+                  type: string
+                  nullable: false
+              required:
+                - api_key
+      responses:
+        '200':
+          description: API key verification result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/verify_api_key_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '401':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis:
+    servers: []
+    get:
+      tags:
+        - APIs
+      operationId: getAPIs
+      x-scope: read:apis
+      summary: Get APIs
+      description: |
+        Returns a list of your APIs. The APIs are returned sorted by name.
+
+        <div>
+          <code>read:apis</code>
+        </div>
+      parameters:
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "scopes".
+          required: false
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - scopes
+      responses:
+        '200':
+          description: A list of APIs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_apis_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - APIs
+      operationId: addAPIs
+      x-scope: create:apis
+      summary: Create API
+      description: |
+        Register a new API. For more information read [Register and manage APIs](https://docs.kinde.com/developer-tools/your-apis/register-manage-apis/).
+
+        <div>
+          <code>create:apis</code>
+        </div>
+      externalDocs:
+        url: https://docs.kinde.com/developer-tools/your-apis/register-manage-apis
+        description: Register and manage APIs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the API. (1-64 characters).
+                  example: Example API
+                audience:
+                  type: string
+                  description: A unique identifier for the API - commonly the URL. This value will be used as the `audience` parameter in authorization claims. (1-64 characters)
+                  example: https://api.example.com
+              required:
+                - name
+                - audience
+      responses:
+        '200':
+          description: APIs successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_apis_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}:
+    servers: []
+    parameters:
+      - $ref: '#/components/parameters/api_id'
+    get:
+      tags:
+        - APIs
+      operationId: getAPI
+      x-scope: read:apis
+      summary: Get API
+      description: |
+        Retrieve API details by ID.
+
+        <div>
+          <code>read:apis</code>
+        </div>
+      responses:
+        '200':
+          description: API successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - APIs
+      operationId: deleteAPI
+      x-scope: delete:apis
+      summary: Delete API
+      description: |
+        Delete an API you previously created.
+
+        <div>
+          <code>delete:apis</code>
+        </div>
+      responses:
+        '200':
+          description: API successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}/scopes:
+    servers: []
+    get:
+      tags:
+        - APIs
+      operationId: getAPIScopes
+      x-scope: read:api_scopes
+      summary: Get API scopes
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+      description: |
+        Retrieve API scopes by API ID.
+
+        <div>
+          <code>read:api_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scopes successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_scopes_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - APIs
+      operationId: addAPIScope
+      x-scope: create:api_scopes
+      summary: Create API scope
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+      description: |
+        Create a new API scope.
+
+        <div>
+          <code>create:api_scopes</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: The key reference for the scope (1-64 characters, no white space).
+                  example: read:logs
+                description:
+                  type: string
+                  description: Description of the api scope purpose.
+                  example: Scope for reading logs.
+              required:
+                - key
+      responses:
+        '200':
+          description: API scopes successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_api_scopes_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}/scopes/{scope_id}:
+    servers: []
+    get:
+      tags:
+        - APIs
+      operationId: getAPIScope
+      summary: Get API scope
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Retrieve API scope by API ID.
+
+        <div>
+          <code>read:api_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scope successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_api_scope_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - APIs
+      operationId: updateAPIScope
+      summary: Update API scope
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Update an API scope.
+
+        <div>
+          <code>update:api_scopes</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  description: Description of the api scope purpose.
+                  example: Scope for reading logs.
+      responses:
+        '200':
+          description: API scope successfully updated
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - APIs
+      operationId: deleteAPIScope
+      summary: Delete API scope
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Delete an API scope you previously created.
+
+        <div>
+          <code>delete:apis_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scope successfully deleted.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}/applications:
+    servers: []
+    parameters:
+      - $ref: '#/components/parameters/api_id'
+    patch:
+      tags:
+        - APIs
+      operationId: updateAPIApplications
+      summary: Authorize API applications
+      description: |
+        Authorize applications to be allowed to request access tokens for an API
+
+        <div>
+          <code>update:apis</code>
+        </div>
+      requestBody:
+        description: The applications you want to authorize.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - applications
+              properties:
+                applications:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - id
+                    properties:
+                      id:
+                        description: The application's Client ID.
+                        type: string
+                        example: d2db282d6214242b3b145c123f0c123
+                      operation:
+                        description: Optional operation, set to 'delete' to revoke authorization for the application. If not set, the application will be authorized.
+                        type: string
+                        example: delete
+      responses:
+        '200':
+          description: Authorized applications updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/authorize_app_api_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/apis/{api_id}/applications/{application_id}/scopes/{scope_id}:
+    servers: []
+    post:
+      tags:
+        - APIs
+      operationId: addAPIApplicationScope
+      summary: Add scope to API application
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: application_id
+          in: path
+          description: Application ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 7643b487c97545aab79257fd13a1085a
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Add a scope to an API application.
+
+        <div>
+          <code>create:api_application_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scope successfully added to API application
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - APIs
+      operationId: deleteAPIApplicationScope
+      summary: Delete API application scope
+      parameters:
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: application_id
+          in: path
+          description: Application ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 7643b487c97545aab79257fd13a1085a
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Delete an API application scope you previously created.
+
+        <div>
+          <code>delete:apis_application_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scope successfully deleted.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications:
+    servers: []
+    get:
+      tags:
+        - Applications
+      operationId: getApplications
+      x-scope: read:applications
+      summary: Get applications
+      description: |
+        Get a list of applications / clients.
+
+        <div>
+          <code>read:applications</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A successful response with a list of applications or an empty list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_applications_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Applications
+      operationId: createApplication
+      x-scope: create:applications
+      summary: Create application
+      description: |
+        Create a new client.
+
+        <div>
+          <code>create:applications</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The application's name.
+                  type: string
+                  example: React Native app
+                type:
+                  description: The application's type. Use `reg` for regular server rendered applications, `spa` for single-page applications, `m2m` for machine-to-machine applications, and `device` for devices and IoT.
+                  type: string
+                  enum:
+                    - reg
+                    - spa
+                    - m2m
+                    - device
+                org_code:
+                  description: Scope an M2M application to an org (Plus plan required).
+                  type: string
+                  example: org_1234567890abcdef
+                  nullable: true
+              required:
+                - name
+                - type
+      responses:
+        '201':
+          description: Application successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_application_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}:
+    servers: []
+    get:
+      tags:
+        - Applications
+      operationId: getApplication
+      summary: Get application
+      description: |
+        Gets an application given the application's ID.
+
+        <div>
+          <code>read:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 20bbffaa4c5e492a962273039d4ae18b
+      responses:
+        '200':
+          description: Application successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_application_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Applications
+      operationId: updateApplication
+      summary: Update Application
+      description: |
+        Updates a client's settings. For more information, read [Applications in Kinde](https://docs.kinde.com/build/applications/about-applications)
+
+        <div>
+          <code>update:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+            example: 20bbffaa4c5e492a962273039d4ae18b
+      requestBody:
+        description: Application details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The application's name.
+                  type: string
+                language_key:
+                  description: The application's language key.
+                  type: string
+                logout_uris:
+                  description: The application's logout uris.
+                  type: array
+                  items:
+                    type: string
+                redirect_uris:
+                  description: The application's redirect uris.
+                  type: array
+                  items:
+                    type: string
+                login_uri:
+                  description: The default login route for resolving session issues.
+                  type: string
+                homepage_uri:
+                  description: The homepage link to your application.
+                  type: string
+      responses:
+        '200':
+          description: Application successfully updated.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Applications
+      operationId: deleteApplication
+      summary: Delete application
+      description: |
+        Delete a client / application.
+
+        <div>
+          <code>delete:applications</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+            example: 20bbffaa4c5e492a962273039d4ae18b
+      responses:
+        '200':
+          description: Application successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/connections:
+    servers: []
+    get:
+      tags:
+        - Applications
+      operationId: GetApplicationConnections
+      description: |
+        Gets all connections for an application.
+
+        <div>
+          <code>read:application_connections</code>
+        </div>
+      summary: Get connections
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 20bbffaa4c5e492a962273039d4ae18b
+      responses:
+        '200':
+          description: Application connections successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/connections/{connection_id}:
+    servers: []
+    post:
+      tags:
+        - Applications
+      operationId: EnableConnection
+      summary: Enable connection
+      description: |
+        Enable an auth connection for an application.
+
+        <div>
+          <code>create:application_connections</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+            example: 20bbffaa4c5e492a962273039d4ae18b
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+            example: conn_0192c16abb53b44277e597d31877ba5b
+      responses:
+        '200':
+          description: Connection successfully enabled.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Applications
+      operationId: RemoveConnection
+      summary: Remove connection
+      description: |
+        Turn off an auth connection for an application
+
+        <div>
+          <code>delete:application_connections</code>
+        </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+            example: 20bbffaa4c5e492a962273039d4ae18b
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+            example: conn_0192c16abb53b44277e597d31877ba5b
+      responses:
+        '200':
+          description: Connection successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/properties:
+    servers: []
+    parameters:
+      - $ref: '#/components/parameters/application_id'
+    get:
+      tags:
+        - Applications
+      operationId: getApplicationPropertyValues
+      summary: Get property values
+      description: |
+        Gets properties for an application by client ID.
+
+        <div>
+          <code>read:application_properties</code>
+        </div>
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/properties/{property_key}:
+    servers: []
+    parameters:
+      - $ref: '#/components/parameters/application_id'
+      - $ref: '#/components/parameters/property_key'
+    put:
+      tags:
+        - Applications
+      operationId: updateApplicationsProperty
+      summary: Update property
+      description: |
+        Update application property value.
+
+        <div>
+          <code>update:application_properties</code>
+        </div>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  oneOf:
+                    - type: string
+                    - type: boolean
+                  description: The new value for the property
+                  example: Some new value
+              required:
+                - value
+      responses:
+        '200':
+          description: Property successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{application_id}/tokens:
+    servers: []
+    patch:
+      tags:
+        - Applications
+      operationId: updateApplicationTokens
+      summary: Update application tokens
+      description: |
+        Configure tokens for an application.
+          <div>
+            <code>update:application_tokens</code>
+          </div>
+      parameters:
+        - name: application_id
+          in: path
+          description: The identifier/client ID for the application.
+          required: true
+          schema:
+            type: string
+            example: 20bbffaa4c5e492a962273039d4ae18b
+      requestBody:
+        description: Application tokens.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                access_token_lifetime:
+                  description: The lifetime of an access token in seconds.
+                  type: integer
+                  example: 3600
+                refresh_token_lifetime:
+                  description: The lifetime of a refresh token in seconds.
+                  type: integer
+                  example: 86400
+                id_token_lifetime:
+                  description: The lifetime of an ID token in seconds.
+                  type: integer
+                  example: 3600
+                authenticated_session_lifetime:
+                  description: The lifetime of an authenticated session in seconds.
+                  type: integer
+                  example: 86400
+                is_hasura_mapping_enabled:
+                  description: Enable or disable Hasura mapping.
+                  type: boolean
+                  example: true
+      responses:
+        '200':
+          description: Application tokens successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/billing/entitlements:
+    servers: []
+    get:
+      tags:
+        - Billing Entitlements
+      operationId: getBillingEntitlements
+      x-scope: read:billing_entitlements
+      description: |
+        Returns all the entitlements a billing customer currently has access to
+
+        <div>
+          <code>read:billing_entitlements</code>
+        </div>
+      summary: Get billing entitlements
+      parameters:
+        - name: page_size
+          in: query
+          required: false
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          required: false
+          description: The ID of the billing entitlement to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          required: false
+          description: The ID of the billing entitlement to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: customer_id
+          in: query
+          description: The ID of the billing customer to retrieve entitlements for
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: max_value
+          in: query
+          description: When the maximum limit of an entitlement is null, this value is returned as the maximum limit
+          schema:
+            type: string
+            nullable: true
+        - name: expand
+          in: query
+          description: Specify additional plan data to retrieve. Use "plans".
+          required: false
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - plans
+      responses:
+        '200':
+          description: Billing entitlements successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_billing_entitlements_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_billing_entitlements_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/billing/agreements:
+    servers: []
+    get:
+      tags:
+        - Billing Agreements
+      operationId: getBillingAgreements
+      description: |
+        Returns all the agreements a billing customer currently has access to
+
+        <div>
+          <code>read:billing_agreements</code>
+        </div>
+      summary: Get billing agreements
+      parameters:
+        - name: page_size
+          in: query
+          required: false
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          required: false
+          description: The ID of the billing agreement to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          required: false
+          description: The ID of the billing agreement to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: customer_id
+          in: query
+          description: The ID of the billing customer to retrieve agreements for
+          required: true
+          schema:
+            type: string
+            nullable: false
+          example: customer_0195ac80a14c2ca2cec97d026d864de0
+        - name: feature_code
+          in: query
+          required: false
+          description: The feature code to filter by agreements only containing that feature
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Billing agreements successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_billing_agreements_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_billing_agreements_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Billing Agreements
+      operationId: createBillingAgreement
+      description: |
+        Creates a new billing agreement based on the plan code passed, and cancels the customer's existing agreements
+
+        <div>
+          <code>create:billing_agreements</code>
+        </div>
+      summary: Create billing agreement
+      requestBody:
+        description: New agreement request values
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - customer_id
+                - plan_code
+              properties:
+                customer_id:
+                  description: The ID of the billing customer to create a new agreement for
+                  type: string
+                  example: customer_0195ac80a14c2ca2cec97d026d864de0
+                plan_code:
+                  description: The code of the billing plan the new agreement will be based on
+                  type: string
+                  example: pro
+                is_invoice_now:
+                  type: boolean
+                  description: Generate a final invoice for any un-invoiced metered usage.
+                  example: true
+                is_prorate:
+                  type: boolean
+                  description: Generate a proration invoice item that credits remaining unused features.
+                  example: true
+      responses:
+        '200':
+          description: Billing agreement successfully changed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/billing/meter_usage:
+    servers: []
+    post:
+      tags:
+        - Billing Meter Usage
+      operationId: createMeterUsageRecord
+      summary: Create meter usage record
+      description: |
+        Create a new meter usage record
+
+        <div>
+          <code>create:meter_usage</code>
+        </div>
+      requestBody:
+        description: Meter usage record
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - customer_agreement_id
+                - billing_feature_code
+                - meter_value
+              properties:
+                customer_agreement_id:
+                  description: The billing agreement against which to record usage
+                  type: string
+                  example: agreement_0195ac80a14c2ca2cec97d026d864de0
+                billing_feature_code:
+                  description: The code of the feature within the agreement against which to record usage
+                  type: string
+                  example: pro_gym
+                meter_value:
+                  description: The value of usage to record
+                  type: string
+                  example: pro_gym
+                meter_usage_timestamp:
+                  type: string
+                  format: date-time
+                  description: The date and time the usage needs to be recorded for (defaults to current date/time)
+                  example: '2024-11-18T13:32:03+11'
+                meter_type_code:
+                  type: string
+                  enum:
+                    - absolute
+                    - delta
+                  description: Absolutes overrides the current usage
+      responses:
+        '200':
+          description: Meter usage record successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_meter_usage_record_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/business:
+    servers: []
+    get:
+      tags:
+        - Business
+      operationId: getBusiness
+      x-scope: read:businesses
+      summary: Get business
+      description: |
+        Get your business details.
+
+        <div>
+          <code>read:businesses</code>
+        </div>
+      responses:
+        '200':
+          description: Your business details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_business_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Business
+      operationId: updateBusiness
+      x-scope: update:businesses
+      summary: Update business
+      description: |
+        Update your business details.
+
+        <div>
+          <code>update:businesses</code>
+        </div>
+      requestBody:
+        description: The business details to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                business_name:
+                  type: string
+                  description: The name of the business.
+                  example: Tailsforce Ltd
+                  nullable: true
+                email:
+                  type: string
+                  description: The email address of the business.
+                  example: sally@example.com
+                  nullable: true
+                industry_key:
+                  type: string
+                  description: The key of the industry of your business. Can be retrieved from the /industries endpoint.
+                  example: construction
+                  nullable: true
+                is_click_wrap:
+                  description: Whether the business is using clickwrap agreements.
+                  type: boolean
+                  example: false
+                  nullable: true
+                is_show_kinde_branding:
+                  description: Whether the business is showing Kinde branding. Requires a paid plan.
+                  type: boolean
+                  example: true
+                  nullable: true
+                kinde_perk_code:
+                  description: The Kinde perk code for the business.
+                  type: string
+                  nullable: true
+                phone:
+                  description: The phone number of the business.
+                  type: string
+                  example: 123-456-7890
+                  nullable: true
+                privacy_url:
+                  description: The URL to the business's privacy policy.
+                  type: string
+                  example: https://example.com/privacy
+                  nullable: true
+                terms_url:
+                  description: The URL to the business's terms of service.
+                  type: string
+                  example: https://example.com/terms
+                  nullable: true
+                timezone_key:
+                  description: The key of the timezone of your business. Can be retrieved from the /timezones endpoint.
+                  type: string
+                  example: los_angeles_pacific_standard_time
+                  nullable: true
+      responses:
+        '200':
+          description: Business successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/industries:
+    servers: []
+    get:
+      tags:
+        - Industries
+      operationId: getIndustries
+      summary: Get industries
+      description: |
+        Get a list of industries and associated industry keys.
+
+        <div>
+          <code>read:industries</code>
+        </div>
+      responses:
+        '200':
+          description: A list of industries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_industries_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/timezones:
+    servers: []
+    get:
+      tags:
+        - Timezones
+      operationId: getTimezones
+      summary: Get timezones
+      description: |
+        Get a list of timezones and associated timezone keys.
+
+        <div>
+          <code>read:timezones</code>
+        </div>
+      responses:
+        '200':
+          description: A list of timezones.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_timezones_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{app_id}/auth_redirect_urls:
+    servers: []
+    get:
+      tags:
+        - Callbacks
+      operationId: getCallbackURLs
+      x-scope: read:applications_redirect_uris
+      description: |
+        Returns an application's redirect callback URLs.
+
+        <div>
+          <code>read:applications_redirect_uris</code>
+        </div>
+      summary: List Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Callback URLs successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/redirect_callback_urls'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/redirect_callback_urls'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Callbacks
+      operationId: addRedirectCallbackURLs
+      x-scope: create:applications_redirect_uris
+      description: |
+        Add additional redirect callback URLs.
+
+        <div>
+          <code>create:applications_redirect_uris</code>
+        </div>
+      summary: Add Redirect Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of callback urls.
+      responses:
+        '200':
+          description: Callbacks successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Callbacks
+      operationId: replaceRedirectCallbackURLs
+      description: |
+        Replace all redirect callback URLs.
+
+        <div>
+          <code>update:applications_redirect_uris</code>
+        </div>
+      summary: Replace Redirect Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of callback urls.
+      responses:
+        '200':
+          description: Callbacks successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Callbacks
+      operationId: deleteCallbackURLs
+      description: |
+        Delete callback URLs.
+
+        <div>
+          <code>delete:applications_redirect_uris</code>
+        </div>
+      summary: Delete Callback URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+        - name: urls
+          in: query
+          description: Urls to delete, comma separated and url encoded.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Callback URLs successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/applications/{app_id}/auth_logout_urls:
+    servers: []
+    get:
+      tags:
+        - Callbacks
+      operationId: getLogoutURLs
+      description: |
+        Returns an application's logout redirect URLs.
+
+        <div>
+          <code>read:application_logout_uris</code>
+        </div>
+      summary: List logout URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Logout URLs successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/logout_redirect_urls'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Callbacks
+      operationId: addLogoutRedirectURLs
+      description: |
+        Add additional logout redirect URLs.
+
+        <div>
+          <code>create:application_logout_uris</code>
+        </div>
+      summary: Add logout redirect URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of logout urls.
+      responses:
+        '200':
+          description: Logout URLs successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Callbacks
+      operationId: replaceLogoutRedirectURLs
+      description: |
+        Replace all logout redirect URLs.
+
+        <div>
+          <code>update:application_logout_uris</code>
+        </div>
+      summary: Replace logout redirect URls
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Callback details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of logout urls.
+      responses:
+        '200':
+          description: Logout URLs successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Callbacks
+      operationId: deleteLogoutURLs
+      description: |
+        Delete logout URLs.
+
+        <div>
+          <code>delete:application_logout_uris</code>
+        </div>
+      summary: Delete Logout URLs
+      parameters:
+        - name: app_id
+          in: path
+          description: The identifier for the application.
+          required: true
+          schema:
+            type: string
+        - name: urls
+          in: query
+          description: Urls to delete, comma separated and url encoded.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Logout URLs successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/auth_url:
+    servers: []
+    get:
+      tags:
+        - Connected Apps
+      operationId: GetConnectedAppAuthUrl
+      x-scope: read:connected_apps
+      description: |
+        Get a URL that authenticates and authorizes a user to a third-party connected app.
+
+        <div>
+          <code>read:connected_apps</code>
+        </div>
+      summary: Get Connected App URL
+      parameters:
+        - name: key_code_ref
+          in: query
+          description: The unique key code reference of the connected app to authenticate against.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: user_id
+          in: query
+          description: The id of the user that needs to authenticate to the third-party connected app.
+          schema:
+            type: string
+            nullable: false
+          required: false
+        - name: org_code
+          in: query
+          description: The code of the Kinde organization that needs to authenticate to the third-party connected app.
+          schema:
+            type: string
+            nullable: false
+          required: false
+        - name: override_callback_url
+          in: query
+          description: A URL that overrides the default callback URL setup in your connected app configuration
+          schema:
+            type: string
+            nullable: false
+          required: false
+      responses:
+        '200':
+          description: A URL that can be used to authenticate and a session id to identify this authentication session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connected_apps_auth_url'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/connected_apps_auth_url'
+        '400':
+          description: Error retrieving connected app auth url.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '404':
+          description: Error retrieving connected app auth url.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/token:
+    servers: []
+    get:
+      tags:
+        - Connected Apps
+      operationId: GetConnectedAppToken
+      x-scope: read:connected_apps
+      description: |
+        Get an access token that can be used to call the third-party provider linked to the connected app.
+
+        <div>
+          <code>read:connected_apps</code>
+        </div>
+      summary: Get Connected App Token
+      parameters:
+        - name: session_id
+          in: query
+          description: The unique sesssion id representing the login session of a user.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: An access token that can be used to query a third-party provider, as well as the token's expiry time.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connected_apps_access_token'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/connected_apps_access_token'
+        '400':
+          description: The session id provided points to an invalid session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connected_apps/revoke:
+    servers: []
+    post:
+      tags:
+        - Connected Apps
+      operationId: RevokeConnectedAppToken
+      description: |
+        Revoke the tokens linked to the connected app session.
+
+        <div>
+          <code>create:connected_apps</code>
+        </div>
+      summary: Revoke Connected App Token
+      parameters:
+        - name: session_id
+          in: query
+          description: The unique sesssion id representing the login session of a user.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: An access token that can be used to query a third-party provider, as well as the token's expiry time.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '405':
+          description: Invalid HTTP method used.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connections:
+    servers: []
+    get:
+      tags:
+        - Connections
+      operationId: GetConnections
+      x-scope: read:connections
+      description: |
+        Returns a list of authentication connections. Optionally you can filter this by a home realm domain.
+
+        <div>
+          <code>read:connections</code>
+        </div>
+      summary: Get connections
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: home_realm_domain
+          in: query
+          description: Filter the results by the home realm domain.
+          schema:
+            example: myapp.com
+            type: string
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the connection to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the connection to end before.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Connections successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Connections
+      operationId: CreateConnection
+      x-scope: create:connections
+      description: |
+        Create Connection.
+
+        <div>
+          <code>create:connections</code>
+        </div>
+      summary: Create Connection
+      requestBody:
+        description: Connection details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The internal name of the connection.
+                  type: string
+                  nullable: false
+                display_name:
+                  description: The public facing name of the connection.
+                  type: string
+                  nullable: false
+                strategy:
+                  description: The identity provider identifier for the connection.
+                  type: string
+                  enum:
+                    - oauth2:apple
+                    - oauth2:azure_ad
+                    - oauth2:bitbucket
+                    - oauth2:discord
+                    - oauth2:facebook
+                    - oauth2:github
+                    - oauth2:gitlab
+                    - oauth2:google
+                    - oauth2:linkedin
+                    - oauth2:microsoft
+                    - oauth2:patreon
+                    - oauth2:slack
+                    - oauth2:stripe
+                    - oauth2:twitch
+                    - oauth2:twitter
+                    - oauth2:xero
+                    - saml:custom
+                    - saml:cloudflare
+                    - saml:okta
+                    - saml:microsoft
+                    - saml:google
+                    - wsfed:azure_ad
+                  nullable: false
+                enabled_applications:
+                  description: Client IDs of applications in which this connection is to be enabled.
+                  type: array
+                  items:
+                    type: string
+                organization_code:
+                  description: Enterprise connections only - the code for organization that manages this connection.
+                  type: string
+                  nullable: true
+                  example: org_80581732fbe
+                options:
+                  oneOf:
+                    - type: object
+                      description: Social connection options (e.g., Google SSO).
+                      properties:
+                        client_id:
+                          type: string
+                          description: OAuth client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: OAuth client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        is_use_custom_domain:
+                          type: boolean
+                          description: Use custom domain callback URL.
+                          example: true
+                    - type: object
+                      description: Azure AD connection options.
+                      properties:
+                        client_id:
+                          type: string
+                          description: Client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: Client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to limit authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        entra_id_domain:
+                          type: string
+                          description: Domain for Entra ID.
+                          example: kinde.com
+                        is_use_common_endpoint:
+                          type: boolean
+                          description: Use https://login.windows.net/common instead of a default endpoint.
+                          example: true
+                        is_sync_user_profile_on_login:
+                          type: boolean
+                          description: Sync user profile data with IDP.
+                          example: true
+                        is_retrieve_provider_user_groups:
+                          type: boolean
+                          description: Include user group info from MS Entra ID.
+                          example: true
+                        is_extended_attributes_required:
+                          type: boolean
+                          description: Include additional user profile information.
+                          example: true
+                        is_auto_join_organization_enabled:
+                          type: boolean
+                          description: Users automatically join organization when using this connection.
+                          example: true
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create a user record in Kinde if the user signing in does not exist.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                    - type: object
+                      description: SAML connection options (e.g., Cloudflare SAML).
+                      properties:
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to restrict authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        saml_entity_id:
+                          type: string
+                          description: SAML Entity ID.
+                          example: https://kinde.com
+                        saml_idp_metadata_url:
+                          type: string
+                          description: URL for the IdP metadata.
+                          example: https://kinde.com/saml/metadata
+                        saml_sign_in_url:
+                          type: string
+                          description: Override the default SSO endpoint with a URL your IdP recognizes.
+                          example: https://kinde.com/saml/signin
+                        saml_email_key_attr:
+                          type: string
+                          description: Attribute key for the user’s email.
+                          example: email
+                        saml_first_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s first name.
+                          example: given_name
+                        saml_last_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s last name.
+                          example: family_name
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create user if they don’t exist.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                        saml_signing_certificate:
+                          type: string
+                          description: Certificate for signing SAML requests.
+                          example: |-
+                            -----BEGIN CERTIFICATE-----
+                            MIIDdTCCAl2gAwIBAgIEUjZoyDANBgkqhkiG9w0BAQsFADBzMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExEjAQBgNVBAcMCVNhbiBGcmFuYzEXMBUGA1UECgwOQ2xv
+                            -----END CERTIFICATE-----
+                        saml_signing_private_key:
+                          type: string
+                          description: Private key associated with the signing certificate.
+                          example: |-
+                            -----BEGIN PRIVATE KEY-----
+                            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCy5+KLjTzF6tvl
+                            -----END PRIVATE KEY-----
+                        is_auto_join_organization_enabled:
+                          type: boolean
+                          description: Users automatically join organization when using this connection.
+                          example: true
+      responses:
+        '201':
+          description: Connection successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_connection_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/connections/{connection_id}:
+    servers: []
+    get:
+      tags:
+        - Connections
+      operationId: GetConnection
+      description: |
+        Get Connection.
+
+        <div>
+          <code>read:connections</code>
+        </div>
+      summary: Get Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The unique identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connection'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Connections
+      operationId: UpdateConnection
+      description: |
+        Update Connection.
+
+        <div>
+          <code>update:connections</code>
+        </div>
+      summary: Update Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The unique identifier for the connection.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the connection to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The internal name of the connection.
+                  type: string
+                  nullable: false
+                  example: ConnectionA
+                display_name:
+                  description: The public facing name of the connection.
+                  type: string
+                  nullable: false
+                  example: Connection
+                enabled_applications:
+                  description: Client IDs of applications in which this connection is to be enabled.
+                  type: array
+                  example:
+                    - c647dbe20f5944e28af97c9184fded22
+                    - 20bbffaa4c5e492a962273039d4ae18b
+                  items:
+                    type: string
+                options:
+                  oneOf:
+                    - type: object
+                      description: Social connection options (e.g., Google SSO).
+                      properties:
+                        client_id:
+                          type: string
+                          description: OAuth client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: OAuth client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        is_use_custom_domain:
+                          type: boolean
+                          description: Use custom domain callback URL.
+                          example: true
+                    - type: object
+                      description: Azure AD connection options.
+                      properties:
+                        client_id:
+                          type: string
+                          description: Client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: Client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to limit authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        entra_id_domain:
+                          type: string
+                          description: Domain for Entra ID.
+                          example: kinde.com
+                        is_use_common_endpoint:
+                          type: boolean
+                          description: Use https://login.windows.net/common instead of a default endpoint.
+                          example: true
+                        is_sync_user_profile_on_login:
+                          type: boolean
+                          description: Sync user profile data with IDP.
+                          example: true
+                        is_retrieve_provider_user_groups:
+                          type: boolean
+                          description: Include user group info from MS Entra ID.
+                          example: true
+                        is_extended_attributes_required:
+                          type: boolean
+                          description: Include additional user profile information.
+                          example: true
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create users if they don't exist in the system.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                    - type: object
+                      description: SAML connection options (e.g., Cloudflare SAML).
+                      properties:
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to restrict authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        saml_entity_id:
+                          type: string
+                          description: SAML Entity ID.
+                          example: https://kinde.com
+                        saml_idp_metadata_url:
+                          type: string
+                          description: URL for the IdP metadata.
+                          example: https://kinde.com/saml/metadata
+                        saml_email_key_attr:
+                          type: string
+                          description: Attribute key for the user’s email.
+                          example: email
+                        saml_first_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s first name.
+                          example: given_name
+                        saml_last_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s last name.
+                          example: family_name
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create user if they don’t exist.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                        saml_signing_certificate:
+                          type: string
+                          description: Certificate for signing SAML requests.
+                          example: |-
+                            -----BEGIN CERTIFICATE-----
+                            MIIDdTCCAl2gAwIBAgIEUjZoyDANBgkqhkiG9w0BAQsFADBzMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExEjAQBgNVBAcMCVNhbiBGcmFuYzEXMBUGA1UECgwOQ2xv
+                            -----END CERTIFICATE-----
+                        saml_signing_private_key:
+                          type: string
+                          description: Private key associated with the signing certificate.
+                          example: |-
+                            -----BEGIN PRIVATE KEY-----
+                            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCy5+KLjTzF6tvl
+                            -----END PRIVATE KEY-----
+      responses:
+        '200':
+          description: Connection successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Connections
+      operationId: ReplaceConnection
+      description: |
+        Replace Connection Config.
+
+        <div>
+          <code>update:connections</code>
+        </div>
+      summary: Replace Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The unique identifier for the connection.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The complete connection configuration to replace the existing one.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The internal name of the connection.
+                  type: string
+                  example: ConnectionA
+                  nullable: false
+                display_name:
+                  description: The public-facing name of the connection.
+                  type: string
+                  example: Connection
+                  nullable: false
+                enabled_applications:
+                  description: Client IDs of applications in which this connection is to be enabled.
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - c647dbe20f5944e28af97c9184fded22
+                    - 20bbffaa4c5e492a962273039d4ae18b
+                options:
+                  oneOf:
+                    - type: object
+                      description: Social connection options (e.g., Google SSO).
+                      properties:
+                        client_id:
+                          type: string
+                          description: OAuth client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: OAuth client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        is_use_custom_domain:
+                          type: boolean
+                          description: Use custom domain callback URL.
+                          example: true
+                    - type: object
+                      description: Azure AD connection options.
+                      properties:
+                        client_id:
+                          type: string
+                          description: Client ID.
+                          example: hji7db2146af332akfldfded22
+                        client_secret:
+                          type: string
+                          description: Client secret.
+                          example: 19fkjdalg521l23fassf3039d4ae18b
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to limit authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        entra_id_domain:
+                          type: string
+                          description: Domain for Entra ID.
+                          example: kinde.com
+                        is_use_common_endpoint:
+                          type: boolean
+                          description: Use https://login.windows.net/common instead of a default endpoint.
+                          example: true
+                        is_sync_user_profile_on_login:
+                          type: boolean
+                          description: Sync user profile data with IDP.
+                          example: true
+                        is_retrieve_provider_user_groups:
+                          type: boolean
+                          description: Include user group info from MS Entra ID.
+                          example: true
+                        is_extended_attributes_required:
+                          type: boolean
+                          description: Include additional user profile information.
+                          example: true
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create a user record in Kinde if the user signing in does not exist.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                    - type: object
+                      description: SAML connection options (e.g., Cloudflare SAML).
+                      properties:
+                        home_realm_domains:
+                          type: array
+                          items:
+                            type: string
+                          description: List of domains to restrict authentication.
+                          example:
+                            - '@kinde.com'
+                            - '@kinde.io'
+                        saml_entity_id:
+                          type: string
+                          description: SAML Entity ID.
+                          example: https://kinde.com
+                        saml_idp_metadata_url:
+                          type: string
+                          description: URL for the IdP metadata.
+                          example: https://kinde.com/saml/metadata
+                        saml_email_key_attr:
+                          type: string
+                          description: Attribute key for the user’s email.
+                          example: email
+                        saml_first_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s first name.
+                          example: given_name
+                        saml_last_name_key_attr:
+                          type: string
+                          description: Attribute key for the user’s last name.
+                          example: family_name
+                        is_create_missing_user:
+                          type: boolean
+                          description: Create user if they don’t exist.
+                          example: true
+                        is_force_show_sso_button:
+                          type: boolean
+                          description: Force showing the SSO button for this connection.
+                          example: false
+                        upstream_params:
+                          type: object
+                          description: Additional upstream parameters to pass to the identity provider.
+                          additionalProperties: true
+                          example:
+                            prompt:
+                              value: select_account
+                        saml_signing_certificate:
+                          type: string
+                          description: Certificate for signing SAML requests.
+                          example: |-
+                            -----BEGIN CERTIFICATE-----
+                            MIIDdTCCAl2gAwIBAgIEUjZoyDANBgkqhkiG9w0BAQsFADBzMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExEjAQBgNVBAcMCVNhbiBGcmFuYzEXMBUGA1UECgwOQ2xv
+                            -----END CERTIFICATE-----
+                        saml_signing_private_key:
+                          type: string
+                          description: Private key associated with the signing certificate.
+                          example: |-
+                            -----BEGIN PRIVATE KEY-----
+                            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCy5+KLjTzF6tvl
+                            -----END PRIVATE KEY-----
+      responses:
+        '200':
+          description: Connection successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Connections
+      operationId: deleteConnection
+      description: |
+        Delete connection.
+
+        <div>
+          <code>delete:connections</code>
+        </div>
+      summary: Delete Connection
+      parameters:
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment:
+    servers: []
+    get:
+      tags:
+        - Environments
+      operationId: getEnvironment
+      x-scope: read:environments
+      summary: Get environment
+      description: |
+        Gets the current environment.
+
+        <div>
+          <code>read:environments</code>
+        </div>
+      responses:
+        '200':
+          description: Environment successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/feature_flags:
+    servers: []
+    delete:
+      tags:
+        - Environments
+      operationId: DeleteEnvironementFeatureFlagOverrides
+      x-scope: delete:environment_feature_flags
+      description: |
+        Delete all environment feature flag overrides.
+
+        <div>
+          <code>delete:environment_feature_flags</code>
+        </div>
+      summary: Delete Environment Feature Flag Overrides
+      responses:
+        '200':
+          description: Feature flag overrides deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    get:
+      tags:
+        - Environments
+      operationId: GetEnvironementFeatureFlags
+      x-scope: read:environment_feature_flags
+      description: |
+        Get environment feature flags.
+
+        <div>
+          <code>read:environment_feature_flags</code>
+        </div>
+      summary: List Environment Feature Flags
+      responses:
+        '200':
+          description: Feature flags retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_feature_flags_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_environment_feature_flags_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/feature_flags/{feature_flag_key}:
+    servers: []
+    delete:
+      tags:
+        - Environments
+      operationId: DeleteEnvironementFeatureFlagOverride
+      description: |
+        Delete environment feature flag override.
+
+        <div>
+          <code>delete:environment_feature_flags</code>
+        </div>
+      summary: Delete Environment Feature Flag Override
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Environments
+      operationId: UpdateEnvironementFeatureFlagOverride
+      description: |
+        Update environment feature flag override.
+
+        <div>
+          <code>update:environment_feature_flags</code>
+        </div>
+      summary: Update Environment Feature Flag Override
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Flag details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  description: The flag override value.
+                  type: string
+                  nullable: false
+              required:
+                - value
+      responses:
+        '200':
+          description: Feature flag override successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/logos:
+    servers: []
+    get:
+      tags:
+        - Environments
+      operationId: ReadLogo
+      description: |
+        Read environment logo details
+
+        <div>
+          <code>read:environments</code>
+        </div>
+      summary: Read logo details
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/read_env_logo_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment/logos/{type}:
+    servers: []
+    put:
+      tags:
+        - Environments
+      operationId: AddLogo
+      description: |
+        Add environment logo
+
+        <div>
+          <code>update:environments</code>
+        </div>
+      summary: Add logo
+      parameters:
+        - name: type
+          in: path
+          description: The type of logo to add.
+          required: true
+          schema:
+            type: string
+            example: dark
+            enum:
+              - dark
+              - light
+      requestBody:
+        description: Logo details.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - logo
+              properties:
+                logo:
+                  type: string
+                  format: binary
+                  description: The logo file to upload.
+      responses:
+        '200':
+          description: Logo successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Environments
+      operationId: DeleteLogo
+      description: |
+        Delete environment logo
+
+        <div>
+          <code>update:environments</code>
+        </div>
+      summary: Delete logo
+      parameters:
+        - name: type
+          in: path
+          description: The type of logo to delete.
+          required: true
+          schema:
+            type: string
+            example: dark
+            enum:
+              - dark
+              - light
+      responses:
+        '200':
+          description: Logo successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '204':
+          description: No logo found to delete
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment_variables:
+    servers: []
+    get:
+      tags:
+        - Environment variables
+      operationId: getEnvironmentVariables
+      x-scope: read:environment_variables
+      summary: Get environment variables
+      description: |
+        Get environment variables. This feature is in beta and admin UI is not yet available.
+
+        <div>
+          <code>read:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: A successful response with a list of environment variables or an empty list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_variables_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Environment variables
+      operationId: createEnvironmentVariable
+      x-scope: create:environment_variables
+      summary: Create environment variable
+      description: |
+        Create a new environment variable. This feature is in beta and admin UI is not yet available.
+
+        <div>
+          <code>create:environment_variables</code>
+        </div>
+      requestBody:
+        description: The environment variable details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: The name of the environment variable (max 128 characters).
+                  example: MY_API_KEY
+                value:
+                  type: string
+                  description: The value of the new environment variable (max 2048 characters).
+                  example: some-secret-value
+                is_secret:
+                  type: boolean
+                  description: Whether the environment variable is sensitive. Secrets are not-readable by you or your team after creation.
+                  example: false
+              required:
+                - key
+                - value
+      responses:
+        '201':
+          description: Environment variable successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/environment_variables/{variable_id}:
+    servers: []
+    parameters:
+      - $ref: '#/components/parameters/variable_id'
+    get:
+      tags:
+        - Environment variables
+      operationId: getEnvironmentVariable
+      x-scope: read:environment_variables
+      summary: Get environment variable
+      description: |
+        Retrieve environment variable details by ID. This feature is in beta and admin UI is not yet available.
+
+        <div>
+          <code>read:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: Environment variable successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Environment variables
+      operationId: updateEnvironmentVariable
+      x-scope: update:environment_variables
+      summary: Update environment variable
+      description: |
+        Update an environment variable you previously created. This feature is in beta and admin UI is not yet available.
+
+        <div>
+          <code>update:environment_variables</code>
+        </div>
+      requestBody:
+        description: The new details for the environment variable
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: The key to update.
+                  example: MY_API_KEY
+                value:
+                  type: string
+                  description: The new value for the environment variable.
+                  example: new-secret-value
+                is_secret:
+                  type: boolean
+                  description: Whether the environment variable is sensitive. Secret variables are not-readable by you or your team after creation.
+      responses:
+        '200':
+          description: Environment variable successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Environment variables
+      operationId: deleteEnvironmentVariable
+      x-scope: delete:environment_variables
+      summary: Delete environment variable
+      description: |
+        Delete an environment variable you previously created. This feature is in beta and admin UI is not yet available.
+
+        <div>
+          <code>delete:environment_variables</code>
+        </div>
+      responses:
+        '200':
+          description: Environment variable successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_environment_variable_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/feature_flags:
+    servers: []
+    post:
+      tags:
+        - Feature Flags
+      operationId: CreateFeatureFlag
+      x-scope: create:feature_flags
+      description: |
+        Create feature flag.
+
+        <div>
+          <code>create:feature_flags</code>
+        </div>
+      summary: Create Feature Flag
+      requestBody:
+        description: Flag details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the flag.
+                  type: string
+                  nullable: false
+                description:
+                  description: Description of the flag purpose.
+                  type: string
+                  nullable: false
+                key:
+                  description: The flag identifier to use in code.
+                  type: string
+                  nullable: false
+                type:
+                  description: The variable type.
+                  type: string
+                  enum:
+                    - str
+                    - int
+                    - bool
+                  nullable: false
+                allow_override_level:
+                  description: Allow the flag to be overridden at a different level.
+                  type: string
+                  enum:
+                    - env
+                    - org
+                    - usr
+                  nullable: false
+                default_value:
+                  description: Default value for the flag used by environments and organizations.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - key
+                - type
+                - default_value
+      responses:
+        '201':
+          description: Feature flag successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/feature_flags/{feature_flag_key}:
+    servers: []
+    delete:
+      tags:
+        - Feature Flags
+      operationId: DeleteFeatureFlag
+      x-scope: delete:feature_flags
+      description: |
+        Delete feature flag
+
+        <div>
+          <code>delete:feature_flags</code>
+        </div>
+      summary: Delete Feature Flag
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    put:
+      tags:
+        - Feature Flags
+      operationId: UpdateFeatureFlag
+      x-scope: update:feature_flags
+      description: |
+        Update feature flag.
+
+        <div>
+          <code>update:feature_flags</code>
+        </div>
+      summary: Replace Feature Flag
+      parameters:
+        - name: feature_flag_key
+          in: path
+          description: The key identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: query
+          description: The name of the flag.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: description
+          in: query
+          description: Description of the flag purpose.
+          schema:
+            type: string
+            nullable: false
+          required: true
+        - name: type
+          in: query
+          description: The variable type
+          schema:
+            type: string
+            enum:
+              - str
+              - int
+              - bool
+            nullable: false
+          required: true
+        - name: allow_override_level
+          in: query
+          description: Allow the flag to be overridden at a different level.
+          schema:
+            type: string
+            enum:
+              - env
+              - org
+            nullable: false
+          required: true
+        - name: default_value
+          in: query
+          description: Default value for the flag used by environments and organizations.
+          schema:
+            type: string
+            nullable: false
+          required: true
+      responses:
+        '200':
+          description: Feature flag successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/identities/{identity_id}:
+    servers: []
+    get:
+      tags:
+        - Identities
+      operationId: GetIdentity
+      x-scope: read:identities
+      description: |
+        Returns an identity by ID
+
+        <div>
+          <code>read:identities</code>
+        </div>
+      summary: Get identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Identity successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/identity'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identity'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Identities
+      operationId: UpdateIdentity
+      x-scope: update:identities
+      description: |
+        Update identity by ID.
+
+        <div>
+          <code>update:identities</code>
+        </div>
+      summary: Update identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the identity to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                is_primary:
+                  description: Whether the identity is the primary for it's type
+                  type: boolean
+                  nullable: false
+      responses:
+        '200':
+          description: Identity successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Identities
+      operationId: DeleteIdentity
+      x-scope: delete:identities
+      description: |
+        Delete identity by ID.
+
+        <div>
+          <code>delete:identities</code>
+        </div>
+      summary: Delete identity
+      parameters:
+        - name: identity_id
+          in: path
+          description: The unique identifier for the identity.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Identity successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/mfa:
+    servers: []
+    put:
+      tags:
+        - MFA
+      operationId: ReplaceMFA
+      x-scope: update:mfa
+      description: |
+        Replace MFA Configuration.
+
+        <div>
+          <code>update:mfa</code>
+        </div>
+      summary: Replace MFA Configuration
+      requestBody:
+        description: MFA details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy:
+                  description: Specifies whether MFA is required, optional, or not enforced.
+                  type: string
+                  enum:
+                    - required
+                    - 'off'
+                    - optional
+                  nullable: false
+                enabled_factors:
+                  description: The MFA methods to enable.
+                  type: array
+                  nullable: false
+                  items:
+                    type: string
+                    enum:
+                      - mfa:email
+                      - mfa:sms
+                      - mfa:authenticator_app
+              required:
+                - policy
+                - enabled_factors
+      responses:
+        '200':
+          description: MFA Configuration updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: getOrganization
+      x-scope: read:organizations
+      summary: Get organization
+      description: |
+        Retrieve organization details by code.
+
+        <div>
+          <code>read:organizations</code>
+        </div>
+      parameters:
+        - in: query
+          name: code
+          description: The organization's code.
+          schema:
+            type: string
+            example: org_1ccfb819462
+        - in: query
+          name: expand
+          description: Specify additional data to retrieve. Use "billing".
+          schema:
+            type: string
+            example: billing
+      responses:
+        '200':
+          description: Organization successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: createOrganization
+      x-scope: create:organizations
+      summary: Create organization
+      description: |
+        Create a new organization. To learn more read about [multi tenancy using organizations](https://docs.kinde.com/build/organizations/multi-tenancy-using-organizations/)
+
+        <div>
+          <code>create:organizations</code>
+        </div>
+      requestBody:
+        description: Organization details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  description: The organization's name.
+                  type: string
+                  example: Acme Corp
+                feature_flags:
+                  type: object
+                  description: The organization's feature flag settings.
+                  additionalProperties:
+                    type: string
+                    enum:
+                      - str
+                      - int
+                      - bool
+                    description: Value of the feature flag.
+                external_id:
+                  description: The organization's external identifier - commonly used when migrating from or mapping to other systems.
+                  type: string
+                  example: some1234
+                background_color:
+                  description: The organization's brand settings - background color.
+                  type: string
+                button_color:
+                  description: The organization's brand settings - button color.
+                  type: string
+                button_text_color:
+                  description: The organization's brand settings - button text color.
+                  type: string
+                link_color:
+                  description: The organization's brand settings - link color.
+                  type: string
+                background_color_dark:
+                  description: The organization's brand settings - dark mode background color.
+                  type: string
+                button_color_dark:
+                  description: The organization's brand settings - dark mode button color.
+                  type: string
+                button_text_color_dark:
+                  description: The organization's brand settings - dark mode button text color.
+                  type: string
+                link_color_dark:
+                  description: The organization's brand settings - dark mode link color.
+                  type: string
+                theme_code:
+                  description: The organization's brand settings - theme/mode 'light' | 'dark' | 'user_preference'.
+                  type: string
+                handle:
+                  description: A unique handle for the organization - can be used for dynamic callback urls.
+                  type: string
+                  example: acme_corp
+                is_allow_registrations:
+                  description: If users become members of this organization when the org code is supplied during authentication.
+                  type: boolean
+                  example: true
+                sender_name:
+                  nullable: true
+                  type: string
+                  example: Acme Corp
+                  description: The name of the organization that will be used in emails
+                sender_email:
+                  nullable: true
+                  type: string
+                  example: hello@acmecorp.com
+                  description: The email address that will be used in emails. Requires custom SMTP to be set up.
+                is_create_billing_customer:
+                  type: boolean
+                  example: false
+                  description: If a billing customer is also created for this organization
+                billing_email:
+                  type: string
+                  example: billing@acmecorp.com
+                  description: The email address used for billing purposes for the organization
+                billing_plan_code:
+                  type: string
+                  example: pro
+                  description: The billing plan to put the customer on. If not specified, the default plan is used
+      responses:
+        '200':
+          description: Organization successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_organization_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: getOrganizations
+      x-scope: read:organizations
+      summary: Get organizations
+      description: |
+        Get a list of organizations.
+
+        <div>
+          <code>read:organizations</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Organizations successfully retreived.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organizations_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization/{org_code}:
+    servers: []
+    patch:
+      tags:
+        - Organizations
+      operationId: updateOrganization
+      description: |
+        Update an organization.
+
+        <div>
+          <code>update:organizations</code>
+        </div>
+      summary: Update Organization
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_1ccfb819462
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "billing".
+          required: false
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - billing
+      requestBody:
+        description: Organization details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The organization's name.
+                  type: string
+                  example: Acme Corp
+                external_id:
+                  description: The organization's ID.
+                  type: string
+                  example: some1234
+                background_color:
+                  description: The organization's brand settings - background color.
+                  type: string
+                  example: '#fff'
+                button_color:
+                  description: The organization's brand settings - button color.
+                  type: string
+                  example: '#fff'
+                button_text_color:
+                  description: The organization's brand settings - button text color.
+                  type: string
+                  example: '#fff'
+                link_color:
+                  description: The organization's brand settings - link color.
+                  type: string
+                  example: '#fff'
+                background_color_dark:
+                  description: The organization's brand settings - dark mode background color.
+                  type: string
+                  example: '#000'
+                button_color_dark:
+                  description: The organization's brand settings - dark mode button color.
+                  type: string
+                  example: '#000'
+                button_text_color_dark:
+                  description: The organization's brand settings - dark mode button text color.
+                  type: string
+                  example: '#000'
+                link_color_dark:
+                  description: The organization's brand settings - dark mode link color.
+                  type: string
+                  example: '#000'
+                theme_code:
+                  description: The organization's brand settings - theme/mode.
+                  type: string
+                  enum:
+                    - light
+                    - dark
+                    - user_preference
+                  example: light
+                handle:
+                  description: The organization's handle.
+                  type: string
+                  example: acme_corp
+                is_allow_registrations:
+                  deprecated: true
+                  description: Deprecated - Use 'is_auto_membership_enabled' instead.
+                  type: boolean
+                is_auto_join_domain_list:
+                  description: Users can sign up to this organization.
+                  type: boolean
+                  example: true
+                allowed_domains:
+                  description: Domains allowed for self-sign up to this environment.
+                  type: array
+                  example:
+                    - https://acme.kinde.com
+                    - https://acme.com
+                  items:
+                    type: string
+                is_enable_advanced_orgs:
+                  description: Activate advanced organization features.
+                  type: boolean
+                  example: true
+                is_enforce_mfa:
+                  description: Enforce MFA for all users in this organization.
+                  type: boolean
+                  example: true
+                sender_name:
+                  nullable: true
+                  type: string
+                  example: Acme Corp
+                  description: The name of the organization that will be used in emails
+                sender_email:
+                  nullable: true
+                  type: string
+                  example: hello@acmecorp.com
+                  description: The email address that will be used in emails. Requires custom SMTP to be set up.
+      responses:
+        '200':
+          description: Organization successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: deleteOrganization
+      description: |
+        Delete an organization.
+
+        <div>
+          <code>delete:organizations</code>
+        </div>
+      summary: Delete Organization
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Organization successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUsers
+      x-scope: read:organization_users
+      summary: Get organization users
+      description: |
+        Get user details for all members of an organization.
+
+        <div>
+          <code>read:organization_users</code>
+        </div>
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            example: email_asc
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            example: 10
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            example: MTo6OmlkX2FzYw==
+            type: string
+            nullable: true
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            example: org_1ccfb819462
+            type: string
+            nullable: false
+        - name: permissions
+          in: query
+          description: Filter by user permissions comma separated (where all match)
+          schema:
+            example: admin
+            type: string
+        - name: roles
+          in: query
+          description: Filter by user roles comma separated (where all match)
+          schema:
+            example: manager
+            type: string
+      responses:
+        '200':
+          description: A successful response with a list of organization users or an empty list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: AddOrganizationUsers
+      description: |
+        Add existing users to an organization.
+
+        <div>
+          <code>create:organization_users</code>
+        </div>
+      summary: Add Organization Users
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: Users to be added to the organization.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The users id.
+                        type: string
+                        example: kp_057ee6debc624c70947b6ba512908c35
+                      roles:
+                        description: Role keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                          example: manager
+                      permissions:
+                        description: Permission keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                          example: admin
+      responses:
+        '200':
+          description: Add organization users request successfully processed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add_organization_users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationUsers
+      description: |
+        Update users that belong to an organization.
+
+        <div>
+          <code>update:organization_users</code>
+        </div>
+      summary: Update Organization Users
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: Users to add, update or remove from the organization.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The users id.
+                        type: string
+                        example: kp_057ee6debc624c70947b6ba512908c35
+                      operation:
+                        description: Optional operation, set to 'delete' to remove the user from the organization.
+                        type: string
+                        example: delete
+                      roles:
+                        description: Role keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                          example: manager
+                      permissions:
+                        description: Permission keys to assign to the user.
+                        type: array
+                        items:
+                          type: string
+                          example: admin
+      responses:
+        '200':
+          description: Users successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_organization_users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/roles:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUserRoles
+      x-scope: read:organization_user_roles
+      description: |
+        Get roles for an organization user.
+
+        <div>
+          <code>read:organization_user_roles</code>
+        </div>
+      summary: List Organization User Roles
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: A successful response with a list of user roles.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_roles_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_roles_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: CreateOrganizationUserRole
+      description: |
+        Add role to an organization user.
+
+        <div>
+          <code>create:organization_user_roles</code>
+        </div>
+      summary: Add Organization User Role
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Role details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role_id:
+                  description: The role id.
+                  type: string
+      responses:
+        '200':
+          description: Role successfully added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/roles/{role_id}:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationUserRole
+      description: |
+        Delete role for an organization user.
+
+        <div>
+          <code>delete:organization_user_roles</code>
+        </div>
+      summary: Delete Organization User Role
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: role_id
+          in: path
+          description: The role id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/permissions:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationUserPermissions
+      x-scope: read:organization_user_permissions
+      description: |
+        Get permissions for an organization user.
+
+        <div>
+          <code>read:organization_user_permissions</code>
+        </div>
+      summary: List Organization User Permissions
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "roles".
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A successful response with a list of user permissions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_organizations_user_permissions_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Organizations
+      operationId: CreateOrganizationUserPermission
+      description: |
+        Add permission to an organization user.
+
+        <div>
+          <code>create:organization_user_permissions</code>
+        </div>
+      summary: Add Organization User Permission
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Permission details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                permission_id:
+                  description: The permission id.
+                  type: string
+      responses:
+        '200':
+          description: User permission successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/permissions/{permission_id}:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationUserPermission
+      description: |
+        Delete permission for an organization user.
+
+        <div>
+          <code>delete:organization_user_permissions</code>
+        </div>
+      summary: Delete Organization User Permission
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: permission_id
+          in: path
+          description: The permission id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: RemoveOrganizationUser
+      description: |
+        Remove user from an organization.
+
+        <div>
+          <code>delete:organization_users</code>
+        </div>
+      summary: Remove Organization User
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: user_id
+          in: path
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: User successfully removed from organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/apis/{api_id}/scopes/{scope_id}:
+    servers: []
+    post:
+      tags:
+        - Organizations
+      operationId: addOrganizationUserAPIScope
+      summary: Add scope to organization user api
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: kp_5ce676e5d6a24bc9aac2fba35a46e958
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Add a scope to an organization user api.
+
+        <div>
+          <code>create:organization_user_api_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: API scope successfully added to organization user api
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: deleteOrganizationUserAPIScope
+      summary: Delete scope from organization user API
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: kp_5ce676e5d6a24bc9aac2fba35a46e958
+        - name: api_id
+          in: path
+          description: API ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: 838f208d006a482dbd8cdb79a9889f68
+        - name: scope_id
+          in: path
+          description: Scope ID
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: api_scope_019391daf58d87d8a7213419c016ac95
+      description: |
+        Delete a scope from an organization user api you previously created.
+
+        <div>
+          <code>delete:organization_user_api_scopes</code>
+        </div>
+      responses:
+        '200':
+          description: Organization user API scope successfully deleted.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/mfa:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrgUserMFA
+      description: |
+        Get an organization user’s MFA configuration.
+
+        <div>
+          <code>read:organization_user_mfa</code>
+        </div>
+      summary: Get an organization user's MFA configuration
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_1ccfb819462
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: Successfully retrieve user's MFA configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_user_mfa_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: ResetOrgUserMFAAll
+      description: |
+        Reset all organization MFA factors for a user.
+
+        <div>
+          <code>delete:organization_user_mfa</code>
+        </div>
+      summary: Reset all organization MFA for a user
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_1ccfb819462
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: User's MFA successfully reset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/users/{user_id}/mfa/{factor_id}:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: ResetOrgUserMFA
+      description: |
+        Reset a specific organization MFA factor for a user.
+
+        <div>
+          <code>delete:organization_user_mfa</code>
+        </div>
+      summary: Reset specific organization MFA for a user
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_1ccfb819462
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+        - name: factor_id
+          in: path
+          description: The identifier for the MFA factor
+          required: true
+          schema:
+            type: string
+            example: mfa_0193278a00ac29b3f6d4e4d462d55c47
+      responses:
+        '200':
+          description: User's MFA successfully reset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/feature_flags:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationFeatureFlags
+      x-scope: read:organization_feature_flags
+      description: |
+        Get all organization feature flags.
+
+        <div>
+          <code>read:organization_feature_flags</code>
+        </div>
+      summary: List Organization Feature Flags
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag overrides successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_organization_feature_flags_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_organization_feature_flags_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationFeatureFlagOverrides
+      description: |
+        Delete all organization feature flag overrides.
+
+        <div>
+          <code>delete:organization_feature_flags</code>
+        </div>
+      summary: Delete Organization Feature Flag Overrides
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag overrides successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/feature_flags/{feature_flag_key}:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationFeatureFlagOverride
+      description: |
+        Delete organization feature flag override.
+
+        <div>
+          <code>delete:organization_feature_flags</code>
+        </div>
+      summary: Delete Organization Feature Flag Override
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization.
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationFeatureFlagOverride
+      description: |
+        Update organization feature flag override.
+
+        <div>
+          <code>update:organization_feature_flags</code>
+        </div>
+      summary: Update Organization Feature Flag Override
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: Override value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/properties/{property_key}:
+    servers: []
+    put:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationProperty
+      description: |
+        Update organization property value.
+
+        <div>
+          <code>update:organization_properties</code>
+        </div>
+      summary: Update Organization Property value
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+        - name: property_key
+          in: path
+          description: The identifier for the property
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: The new property value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/properties:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationPropertyValues
+      description: |
+        Gets properties for an organization by org code.
+
+        <div>
+          <code>read:organization_properties</code>
+        </div>
+      summary: Get Organization Property Values
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationProperties
+      description: |
+        Update organization property values.
+
+        <div>
+          <code>update:organization_properties</code>
+        </div>
+      summary: Update Organization Property values
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Properties to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                properties:
+                  description: Property keys and values
+                  type: object
+                  nullable: false
+              required:
+                - properties
+      responses:
+        '200':
+          description: Properties successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/mfa:
+    servers: []
+    put:
+      tags:
+        - Organizations
+      operationId: ReplaceOrganizationMFA
+      description: |
+        Replace Organization MFA Configuration.
+
+        <div>
+          <code>update:organization_mfa</code>
+        </div>
+      summary: Replace Organization MFA Configuration
+      parameters:
+        - name: org_code
+          in: path
+          description: The identifier for the organization
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: MFA details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled_factors:
+                  description: The MFA methods to enable.
+                  type: array
+                  nullable: false
+                  items:
+                    type: string
+                    enum:
+                      - mfa:email
+                      - mfa:sms
+                      - mfa:authenticator_app
+              required:
+                - enabled_factors
+      responses:
+        '200':
+          description: MFA Configuration updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organization/{org_code}/handle:
+    servers: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationHandle
+      description: |
+        Delete organization handle
+
+        <div>
+          <code>delete:organization_handles</code>
+        </div>
+      summary: Delete organization handle
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Handle successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/logos:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: ReadOrganizationLogo
+      description: |
+        Read organization logo details
+
+        <div>
+          <code>read:organizations</code>
+        </div>
+      summary: Read organization logo details
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: org_1ccfb819462
+      responses:
+        '200':
+          description: Successfully retrieved organization logo details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/read_logo_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/logos/{type}:
+    servers: []
+    post:
+      tags:
+        - Organizations
+      operationId: AddOrganizationLogo
+      description: |
+        Add organization logo
+
+        <div>
+          <code>update:organizations</code>
+        </div>
+      summary: Add organization logo
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: org_1ccfb819462
+        - name: type
+          in: path
+          description: The type of logo to add.
+          required: true
+          schema:
+            type: string
+            example: dark
+            enum:
+              - dark
+              - light
+      requestBody:
+        description: Organization logo details.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - logo
+              properties:
+                logo:
+                  type: string
+                  format: binary
+                  description: The logo file to upload.
+      responses:
+        '200':
+          description: Organization logo successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: DeleteOrganizationLogo
+      description: |
+        Delete organization logo
+
+        <div>
+          <code>update:organizations</code>
+        </div>
+      summary: Delete organization logo
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: org_1ccfb819462
+        - name: type
+          in: path
+          description: The type of logo to delete.
+          required: true
+          schema:
+            type: string
+            example: dark
+            enum:
+              - dark
+              - light
+      responses:
+        '200':
+          description: Organization logo successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '204':
+          description: No logo found to delete
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{organization_code}/connections:
+    servers: []
+    get:
+      tags:
+        - Organizations
+      operationId: GetOrganizationConnections
+      description: |
+        Gets all connections for an organization.
+
+        <div>
+          <code>read:organization_connections</code>
+        </div>
+      summary: Get connections
+      parameters:
+        - name: organization_code
+          in: path
+          description: The organization code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: org_7d45b01ef13
+      responses:
+        '200':
+          description: Organization connections successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_connections_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{organization_code}/connections/{connection_id}:
+    servers: []
+    post:
+      tags:
+        - Organizations
+      operationId: EnableOrgConnection
+      summary: Enable connection
+      description: |
+        Enable an auth connection for an organization.
+
+        <div>
+          <code>create:organization_connections</code>
+        </div>
+      parameters:
+        - name: organization_code
+          in: path
+          description: The unique code for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_7d45b01ef13
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+            example: conn_0192c16abb53b44277e597d31877ba5b
+      responses:
+        '200':
+          description: Connection successfully enabled.
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Organizations
+      operationId: RemoveOrgConnection
+      summary: Remove connection
+      description: |
+        Turn off an auth connection for an organization
+
+        <div>
+          <code>delete:organization_connections</code>
+        </div>
+      parameters:
+        - name: organization_code
+          in: path
+          description: The unique code for the organization.
+          required: true
+          schema:
+            type: string
+            example: org_7d45b01ef13
+        - name: connection_id
+          in: path
+          description: The identifier for the connection.
+          required: true
+          schema:
+            type: string
+            example: conn_0192c16abb53b44277e597d31877ba5b
+      responses:
+        '200':
+          description: Connection successfully removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/organizations/{org_code}/sessions:
+    servers: []
+    patch:
+      tags:
+        - Organizations
+      operationId: UpdateOrganizationSessions
+      description: |
+        Update the organization's session configuration.
+
+        <div>
+          <code>update:organizations</code>
+        </div>
+      summary: Update organization session configuration
+      parameters:
+        - name: org_code
+          in: path
+          description: The organization's code.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: org_1ccfb819462
+      requestBody:
+        description: Organization session configuration.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                is_use_org_sso_session_policy:
+                  type: boolean
+                  description: Whether to use the organization's SSO session policy override.
+                sso_session_persistence_mode:
+                  type: string
+                  enum:
+                    - persistent
+                    - non_persistent
+                  description: Determines if the session should be persistent or not.
+                is_use_org_authenticated_session_lifetime:
+                  type: boolean
+                  description: Whether to apply the organization's authenticated session lifetime override.
+                authenticated_session_lifetime:
+                  type: integer
+                  description: Authenticated session lifetime in seconds.
+                  example: 86400
+      responses:
+        '200':
+          description: Organization sessions successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/permissions:
+    servers: []
+    get:
+      tags:
+        - Permissions
+      operationId: GetPermissions
+      x-scope: read:permissions
+      description: |
+        The returned list can be sorted by permission name or permission ID in ascending or descending order. The number of records to return at a time can also be controlled using the `page_size` query string parameter.
+
+        <div>
+          <code>read:permissions</code>
+        </div>
+      summary: List Permissions
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Permissions successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_permissions_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Permissions
+      operationId: CreatePermission
+      x-scope: create:permissions
+      description: |
+        Create a new permission.
+
+        <div>
+          <code>create:permissions</code>
+        </div>
+      summary: Create Permission
+      requestBody:
+        description: Permission details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The permission's name.
+                  type: string
+                description:
+                  description: The permission's description.
+                  type: string
+                key:
+                  description: The permission identifier to use in code.
+                  type: string
+      responses:
+        '201':
+          description: Permission successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/permissions/{permission_id}:
+    servers: []
+    patch:
+      tags:
+        - Permissions
+      operationId: UpdatePermissions
+      x-scope: update:permissions
+      description: |
+        Update permission
+
+        <div>
+          <code>update:permissions</code>
+        </div>
+      summary: Update Permission
+      parameters:
+        - name: permission_id
+          in: path
+          description: The identifier for the permission.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Permission details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The permission's name.
+                  type: string
+                description:
+                  description: The permission's description.
+                  type: string
+                key:
+                  description: The permission identifier to use in code.
+                  type: string
+      responses:
+        '200':
+          description: Permission successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Permissions
+      operationId: DeletePermission
+      x-scope: delete:permissions
+      description: |
+        Delete permission
+
+        <div>
+          <code>delete:permissions</code>
+        </div>
+      summary: Delete Permission
+      parameters:
+        - name: permission_id
+          in: path
+          description: The identifier for the permission.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: permission successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/properties:
+    servers: []
+    get:
+      tags:
+        - Properties
+      operationId: GetProperties
+      x-scope: read:properties
+      description: |
+        Returns a list of properties
+
+        <div>
+          <code>read:properties</code>
+        </div>
+      summary: List properties
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the property to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the property to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: context
+          in: query
+          description: Filter results by user,  organization or application context
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - usr
+              - org
+              - app
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_properties_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_properties_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Properties
+      operationId: CreateProperty
+      x-scope: create:properties
+      description: |
+        Create property.
+
+        <div>
+          <code>create:properties</code>
+        </div>
+      summary: Create Property
+      requestBody:
+        description: Property details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the property.
+                  type: string
+                  nullable: false
+                description:
+                  description: Description of the property purpose.
+                  type: string
+                  nullable: false
+                key:
+                  description: The property identifier to use in code.
+                  type: string
+                  nullable: false
+                type:
+                  description: The property type.
+                  type: string
+                  enum:
+                    - single_line_text
+                    - multi_line_text
+                  nullable: false
+                context:
+                  description: The context that the property applies to.
+                  type: string
+                  enum:
+                    - org
+                    - usr
+                    - app
+                  nullable: false
+                is_private:
+                  description: Whether the property can be included in id and access tokens.
+                  type: boolean
+                  nullable: false
+                category_id:
+                  description: Which category the property belongs to.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - key
+                - type
+                - context
+                - is_private
+                - category_id
+      responses:
+        '201':
+          description: Property successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_property_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_property_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/properties/{property_id}:
+    servers: []
+    put:
+      tags:
+        - Properties
+      operationId: UpdateProperty
+      x-scope: update:properties
+      description: |
+        Update property.
+
+        <div>
+          <code>update:properties</code>
+        </div>
+      summary: Update Property
+      parameters:
+        - name: property_id
+          in: path
+          description: The unique identifier for the property.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the property to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the property.
+                  type: string
+                  nullable: false
+                description:
+                  type: string
+                  description: Description of the property purpose.
+                is_private:
+                  type: boolean
+                  description: Whether the property can be included in id and access tokens.
+                category_id:
+                  description: Which category the property belongs to.
+                  type: string
+                  nullable: false
+              required:
+                - name
+                - is_private
+                - category_id
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Properties
+      operationId: DeleteProperty
+      x-scope: delete:properties
+      description: |
+        Delete property.
+
+        <div>
+          <code>delete:properties</code>
+        </div>
+      summary: Delete Property
+      parameters:
+        - name: property_id
+          in: path
+          description: The unique identifier for the property.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/property_categories:
+    servers: []
+    get:
+      tags:
+        - Property Categories
+      operationId: GetCategories
+      x-scope: read:property_categories
+      description: |
+        Returns a list of categories.
+
+        <div>
+          <code>read:property_categories</code>
+        </div>
+      summary: List categories
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: starting_after
+          in: query
+          description: The ID of the category to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the category to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: context
+          in: query
+          description: Filter the results by User or Organization context
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - usr
+              - org
+      responses:
+        '200':
+          description: Categories successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_categories_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_categories_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Property Categories
+      operationId: CreateCategory
+      x-scope: create:property_categories
+      description: |
+        Create category.
+
+        <div>
+          <code>create:property_categories</code>
+        </div>
+      summary: Create Category
+      requestBody:
+        description: Category details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the category.
+                  type: string
+                  nullable: false
+                context:
+                  description: The context that the category applies to.
+                  type: string
+                  enum:
+                    - org
+                    - usr
+                    - app
+                  nullable: false
+              required:
+                - name
+                - context
+      responses:
+        '201':
+          description: Category successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_category_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_category_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/property_categories/{category_id}:
+    servers: []
+    put:
+      tags:
+        - Property Categories
+      operationId: UpdateCategory
+      description: |
+        Update category.
+
+        <div>
+          <code>update:property_categories</code>
+        </div>
+      summary: Update Category
+      parameters:
+        - name: category_id
+          in: path
+          description: The unique identifier for the category.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The fields of the category to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the category.
+                  type: string
+                  nullable: false
+      responses:
+        '200':
+          description: category successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles:
+    servers: []
+    get:
+      tags:
+        - Roles
+      operationId: GetRoles
+      x-scope: read:roles
+      description: |
+        The returned list can be sorted by role name or role ID in ascending or descending order. The number of records to return at a time can also be controlled using the `page_size` query string parameter.
+
+        <div>
+          <code>read:roles</code>
+        </div>
+      summary: List roles
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Roles successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_roles_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Roles
+      operationId: CreateRole
+      x-scope: create:roles
+      description: |
+        Create role.
+
+        <div>
+          <code>create:roles</code>
+        </div>
+      summary: Create role
+      requestBody:
+        description: Role details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The role's name.
+                  type: string
+                description:
+                  description: The role's description.
+                  type: string
+                key:
+                  description: The role identifier to use in code.
+                  type: string
+                is_default_role:
+                  description: Set role as default for new users.
+                  type: boolean
+                assignment_permission_id:
+                  description: The public ID of the permission required to assign this role to users. If null, no permission is required.
+                  type: string
+                  format: uuid
+                  nullable: true
+      responses:
+        '201':
+          description: Role successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_roles_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}:
+    servers: []
+    get:
+      tags:
+        - Roles
+      operationId: GetRole
+      x-scope: read:roles
+      description: |
+        Get a role
+
+        <div>
+          <code>read:roles</code>
+        </div>
+      summary: Get role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Role successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_role_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Roles
+      operationId: UpdateRoles
+      x-scope: update:roles
+      description: |
+        Update a role
+
+        <div>
+          <code>update:roles</code>
+        </div>
+      summary: Update role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          schema:
+            type: string
+          required: true
+      requestBody:
+        description: Role details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The role's name.
+                  type: string
+                description:
+                  description: The role's description.
+                  type: string
+                key:
+                  description: The role identifier to use in code.
+                  type: string
+                is_default_role:
+                  description: Set role as default for new users.
+                  type: boolean
+                assignment_permission_id:
+                  description: The public ID of the permission required to assign this role to users. If null, no change to the assignment permission is made. If set to 'NO_PERMISSION_REQUIRED', no permission is required.
+                  type: string
+                  format: uuid
+                  nullable: true
+              required:
+                - name
+                - key
+      responses:
+        '201':
+          description: Role successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Roles
+      operationId: DeleteRole
+      x-scope: delete:roles
+      description: |
+        Delete role
+
+        <div>
+          <code>delete:roles</code>
+        </div>
+      summary: Delete role
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Role successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/scopes:
+    servers: []
+    get:
+      tags:
+        - Roles
+      operationId: GetRoleScopes
+      x-scope: read:role_scopes
+      description: |
+        Get scopes for a role.
+
+        <div>
+          <code>read:role_scopes</code>
+        </div>
+      summary: Get role scopes
+      parameters:
+        - name: role_id
+          in: path
+          description: The role id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: A list of scopes for a role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/role_scopes_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/role_scopes_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Roles
+      operationId: AddRoleScope
+      x-scope: create:role_scopes
+      description: |
+        Add scope to role.
+
+        <div>
+          <code>create:role_scopes</code>
+        </div>
+      summary: Add role scope
+      parameters:
+        - name: role_id
+          in: path
+          description: The role id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Add scope to role.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                scope_id:
+                  description: The scope identifier.
+                  type: string
+              required:
+                - scope_id
+      responses:
+        '201':
+          description: Role scope successfully added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add_role_scope_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/scopes/{scope_id}:
+    servers: []
+    delete:
+      tags:
+        - Roles
+      operationId: DeleteRoleScope
+      x-scope: delete:role_scopes
+      description: |
+        Delete scope from role.
+
+        <div>
+          <code>delete:role_scopes</code>
+        </div>
+      summary: Delete role scope
+      parameters:
+        - name: role_id
+          in: path
+          description: The role id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: scope_id
+          in: path
+          description: The scope id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Role scope successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_role_scope_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/permissions:
+    servers: []
+    get:
+      tags:
+        - Roles
+      operationId: GetRolePermissions
+      x-scope: read:role_permissions
+      description: |
+        Get permissions for a role.
+
+        <div>
+          <code>read:role_permissions</code>
+        </div>
+      summary: Get role permissions
+      parameters:
+        - name: role_id
+          in: path
+          description: The role's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - id_asc
+              - id_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: A list of permissions for a role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/role_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/role_permissions_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Roles
+      operationId: UpdateRolePermissions
+      x-scope: update:role_permissions
+      description: |
+        Update role permissions.
+
+        <div>
+          <code>update:role_permissions</code>
+        </div>
+      summary: Update role permissions
+      parameters:
+        - name: role_id
+          in: path
+          description: The identifier for the role.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                permissions:
+                  description: Permissions to add or remove from the role.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The permission id.
+                        type: string
+                      operation:
+                        description: Optional operation, set to 'delete' to remove the permission from the role.
+                        type: string
+      responses:
+        '200':
+          description: Permissions successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_role_permissions_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/update_role_permissions_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/roles/{role_id}/permissions/{permission_id}:
+    servers: []
+    delete:
+      tags:
+        - Roles
+      operationId: RemoveRolePermission
+      x-scope: delete:role_permissions
+      description: |
+        Remove a permission from a role.
+
+        <div>
+          <code>delete:role_permissions</code>
+        </div>
+      summary: Remove role permission
+      parameters:
+        - name: role_id
+          in: path
+          description: The role's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: permission_id
+          in: path
+          description: The permission's public id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Permission successfully removed from role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error removing user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/search/users:
+    servers: []
+    get:
+      tags:
+        - Search
+      operationId: searchUsers
+      x-scope: read:users
+      description: |
+        Search for users based on the provided query string. Set query to '*' to filter by other parameters only.
+        The number of records to return at a time can be controlled using the `page_size` query string parameter.
+
+        <div>
+          <code>read:users</code>
+        </div>
+      summary: Search users
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: query
+          in: query
+          description: Search the users by email or name. Use '*' to search all.
+          schema:
+            type: string
+            nullable: true
+        - name: api_scopes
+          in: query
+          description: Search the users by api scopes.
+          schema:
+            type: string
+            nullable: true
+        - name: properties
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+        - name: starting_after
+          in: query
+          description: The ID of the user to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the user to end before.
+          schema:
+            type: string
+            nullable: true
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "organizations" and/or "identities".
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Users successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/search_users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/subscribers:
+    servers: []
+    get:
+      tags:
+        - Subscribers
+      operationId: GetSubscribers
+      x-scope: read:subscribers
+      description: |
+        The returned list can be sorted by full name or email address
+        in ascending or descending order. The number of records to return at a time can also be controlled using the `page_size` query
+        string parameter.
+
+        <div>
+          <code>read:subscribers</code>
+        </div>
+      summary: List Subscribers
+      parameters:
+        - name: sort
+          in: query
+          description: Field and order to sort the result by.
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - name_asc
+              - name_desc
+              - email_asc
+              - email_desc
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Subscriber successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_subscribers_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_subscribers_response'
+        '403':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Subscribers
+      operationId: CreateSubscriber
+      x-scope: create:subscribers
+      description: |
+        Create subscriber.
+
+        <div>
+          <code>create:subscribers</code>
+        </div>
+      summary: Create Subscriber
+      parameters:
+        - name: first_name
+          in: query
+          description: Subscriber's first name.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: last_name
+          in: query
+          description: Subscriber's last name.
+          required: true
+          schema:
+            type: string
+            nullable: true
+        - name: email
+          in: query
+          description: The email address of the subscriber.
+          required: true
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '201':
+          description: Subscriber successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_subscriber_success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_subscriber_success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/subscribers/{subscriber_id}:
+    servers: []
+    get:
+      tags:
+        - Subscribers
+      operationId: GetSubscriber
+      x-scope: read:subscribers
+      description: |
+        Retrieve a subscriber record.
+
+        <div>
+          <code>read:subscribers</code>
+        </div>
+      summary: Get Subscriber
+      parameters:
+        - name: subscriber_id
+          in: path
+          description: The subscriber's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Subscriber successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_subscriber_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_subscriber_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: getUsers
+      x-scope: read:users
+      description: |
+        The returned list can be sorted by full name or email address in ascending or descending order. The number of records to return at a time can also be controlled using the `page_size` query string parameter.
+
+        <div>
+          <code>read:users</code>
+        </div>
+      summary: Get users
+      parameters:
+        - name: page_size
+          in: query
+          description: Number of results per page. Defaults to 10 if parameter not sent.
+          schema:
+            type: integer
+            nullable: true
+        - name: user_id
+          in: query
+          description: Filter the results by User ID. The query string should be comma separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: next_token
+          in: query
+          description: A string to get the next page of results if there are more results.
+          schema:
+            type: string
+            nullable: true
+        - name: email
+          in: query
+          description: Filter the results by email address. The query string should be comma separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: username
+          in: query
+          description: Filter the results by username. The query string should be comma separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: phone
+          in: query
+          description: Filter the results by phone. The query string should be comma separated and url encoded.
+          schema:
+            type: string
+            nullable: true
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "organizations", "identities" and/or "billing".
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: has_organization
+          in: query
+          description: Filter the results by if the user has at least one organization assigned.
+          required: false
+          schema:
+            type: boolean
+            nullable: true
+        - name: active_since
+          in: query
+          description: Filter the results to only include users who have been active since this date. Date should be in ISO 8601 format.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
+      responses:
+        '200':
+          description: Users successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/users_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/refresh_claims:
+    servers: []
+    post:
+      tags:
+        - Users
+      operationId: refreshUserClaims
+      x-scope: update:user_refresh_claims
+      description: |
+        Refreshes the user's claims and invalidates the current cache.
+
+        <div>
+          <code>update:user_refresh_claims</code>
+        </div>
+      summary: Refresh User Claims and Invalidate Cache
+      parameters:
+        - in: path
+          name: user_id
+          schema:
+            type: string
+          required: true
+          description: The id of the user whose claims needs to be updated.
+      responses:
+        '200':
+          description: Claims successfully refreshed.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Bad request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/user:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: getUserData
+      x-scope: read:users
+      description: |
+        Retrieve a user record.
+
+        <div>
+          <code>read:users</code>
+        </div>
+      summary: Get user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: expand
+          in: query
+          description: Specify additional data to retrieve. Use "organizations", "identities" and/or "billing".
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: User successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Users
+      operationId: createUser
+      description: |
+        Creates a user record and optionally zero or more identities for the user. An example identity could be the email
+        address of the user.
+
+        <div>
+          <code>create:users</code>
+        </div>
+      summary: Create user
+      requestBody:
+        description: The details of the user to create.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile:
+                  description: Basic information required to create a user.
+                  type: object
+                  properties:
+                    given_name:
+                      type: string
+                      description: User's first name.
+                    family_name:
+                      type: string
+                      description: User's last name.
+                    picture:
+                      type: string
+                      description: The user's profile picture.
+                organization_code:
+                  description: The unique code associated with the organization you want the user to join.
+                  type: string
+                provided_id:
+                  description: An external id to reference the user.
+                  type: string
+                identities:
+                  type: array
+                  description: Array of identities to assign to the created user
+                  items:
+                    type: object
+                    description: The result of the user creation operation.
+                    properties:
+                      type:
+                        type: string
+                        description: The type of identity to create, e.g. email, username, or phone.
+                        enum:
+                          - email
+                          - phone
+                          - username
+                      is_verified:
+                        type: boolean
+                        description: Set whether an email or phone identity is verified or not.
+                        example: true
+                      details:
+                        type: object
+                        description: Additional details required to create the user.
+                        properties:
+                          email:
+                            type: string
+                            description: The email address of the user.
+                            example: email@email.com
+                          phone:
+                            type: string
+                            description: The phone number of the user.
+                            example: '+61426148233'
+                          phone_country_id:
+                            type: string
+                            description: The country code for the phone number.
+                            example: au
+                          username:
+                            type: string
+                            description: The username of the user.
+                            example: myusername
+                  example:
+                    - type: email
+                      is_verified: true
+                      details:
+                        email: email@email.com
+                    - type: phone
+                      is_verified: false
+                      details:
+                        phone: '+61426148233'
+                        phone_country_id: au
+                    - type: username
+                      details:
+                        username: myusername
+      responses:
+        '200':
+          description: User successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_user_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Users
+      operationId: updateUser
+      description: |
+        Update a user record.
+
+        <div>
+          <code>update:users</code>
+        </div>
+      summary: Update user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: The user to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                given_name:
+                  type: string
+                  description: User's first name.
+                family_name:
+                  type: string
+                  description: User's last name.
+                picture:
+                  type: string
+                  description: The user's profile picture.
+                is_suspended:
+                  type: boolean
+                  description: Whether the user is currently suspended or not.
+                is_password_reset_requested:
+                  type: boolean
+                  description: Prompt the user to change their password on next sign in.
+                provided_id:
+                  description: An external id to reference the user.
+                  type: string
+      responses:
+        '200':
+          description: User successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_user_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Users
+      operationId: deleteUser
+      description: |
+        Delete a user record.
+
+        <div>
+          <code>delete:users</code>
+        </div>
+      summary: Delete user
+      parameters:
+        - name: id
+          in: query
+          description: The user's id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+            example: kp_c3143a4b50ad43c88e541d9077681782
+        - name: is_delete_profile
+          in: query
+          description: Delete all data and remove the user's profile from all of Kinde, including the subscriber list
+          schema:
+            type: boolean
+            nullable: false
+            example: true
+      responses:
+        '200':
+          description: User successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/feature_flags/{feature_flag_key}:
+    servers: []
+    patch:
+      tags:
+        - Users
+      operationId: UpdateUserFeatureFlagOverride
+      description: |
+        Update user feature flag override.
+
+        <div>
+          <code>update:user_feature_flags</code>
+        </div>
+      summary: Update User Feature Flag Override
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+        - name: feature_flag_key
+          in: path
+          description: The identifier for the feature flag
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: Override value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Feature flag override successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/properties/{property_key}:
+    servers: []
+    put:
+      tags:
+        - Users
+      operationId: UpdateUserProperty
+      description: |
+        Update property value.
+
+        <div>
+          <code>update:user_properties</code>
+        </div>
+      summary: Update Property value
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+        - name: property_key
+          in: path
+          description: The identifier for the property
+          required: true
+          schema:
+            type: string
+        - name: value
+          in: query
+          description: The new property value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/properties:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: GetUserPropertyValues
+      description: |
+        Gets properties for an user by ID.
+
+        <div>
+          <code>read:user_properties</code>
+        </div>
+      summary: Get property values
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Properties successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_property_values_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Users
+      operationId: UpdateUserProperties
+      description: |
+        Update property values.
+
+        <div>
+          <code>update:user_properties</code>
+        </div>
+      summary: Update Property values
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Properties to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                properties:
+                  description: Property keys and values
+                  type: object
+                  nullable: false
+              required:
+                - properties
+      responses:
+        '200':
+          description: Properties successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/password:
+    servers: []
+    put:
+      tags:
+        - Users
+      operationId: SetUserPassword
+      description: |
+        Set user password.
+
+        <div>
+          <code>update:user_passwords</code>
+        </div>
+      summary: Set User password
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Password details.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hashed_password:
+                  description: The hashed password.
+                  type: string
+                hashing_method:
+                  description: The hashing method or algorithm used to encrypt the user’s password. Default is bcrypt.
+                  type: string
+                  enum:
+                    - bcrypt
+                    - crypt
+                    - md5
+                    - wordpress
+                salt:
+                  type: string
+                  description: Extra characters added to passwords to make them stronger. Not required for bcrypt.
+                salt_position:
+                  type: string
+                  description: Position of salt in password string. Not required for bcrypt.
+                  enum:
+                    - prefix
+                    - suffix
+                is_temporary_password:
+                  type: boolean
+                  description: The user will be prompted to set a new password after entering this one.
+              required:
+                - hashed_password
+      responses:
+        '200':
+          description: User successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          description: Error creating user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/identities:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: GetUserIdentities
+      x-scope: read:user_identities
+      description: |
+        Gets a list of identities for an user by ID.
+
+        <div>
+          <code>read:user_identities</code>
+        </div>
+      summary: Get identities
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: starting_after
+          in: query
+          description: The ID of the identity to start after.
+          schema:
+            type: string
+            nullable: true
+        - name: ending_before
+          in: query
+          description: The ID of the identity to end before.
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: Identities successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_identities_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_identities_response'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Users
+      operationId: CreateUserIdentity
+      description: |
+        Creates an identity for a user.
+
+        <div>
+          <code>create:user_identities</code>
+        </div>
+      summary: Create identity
+      parameters:
+        - name: user_id
+          in: path
+          description: The user's ID.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: The identity details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  type: string
+                  description: The email address, social identity, or username of the user.
+                  example: sally@example.com
+                type:
+                  type: string
+                  description: The identity type
+                  enum:
+                    - email
+                    - username
+                    - phone
+                    - enterprise
+                    - social
+                  example: email
+                phone_country_id:
+                  type: string
+                  description: The country code for the phone number, only required when identity type is 'phone'.
+                  example: au
+                connection_id:
+                  type: string
+                  description: The social or enterprise connection ID, only required when identity type is 'social' or 'enterprise'.
+                  example: conn_019289347f1193da6c0e4d49b97b4bd2
+      responses:
+        '201':
+          description: Identity successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_identity_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_identity_response'
+        '400':
+          description: Error creating identity.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/sessions:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: GetUserSessions
+      description: |
+        Retrieve the list of active sessions for a specific user.
+
+        <div>
+          <code>read:user_sessions</code>
+        </div>
+      summary: Get user sessions
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: Successfully retrieved user sessions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_user_sessions_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Users
+      operationId: DeleteUserSessions
+      description: |
+        Invalidate user sessions.
+
+        <div>
+          <code>delete:user_sessions</code>
+        </div>
+      summary: Delete user sessions
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: User sessions successfully invalidated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/mfa:
+    servers: []
+    get:
+      tags:
+        - Users
+      operationId: GetUsersMFA
+      description: |
+        Get a user’s MFA configuration.
+
+        <div>
+          <code>read:user_mfa</code>
+        </div>
+      summary: Get user's MFA configuration
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: Successfully retrieve user's MFA configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_user_mfa_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+    delete:
+      tags:
+        - Users
+      operationId: ResetUsersMFAAll
+      description: |
+        Reset all environment MFA factors for a user.
+
+        <div>
+          <code>delete:user_mfa</code>
+        </div>
+      summary: Reset all environment MFA for a user
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+      responses:
+        '200':
+          description: User's MFA successfully reset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/users/{user_id}/mfa/{factor_id}:
+    servers: []
+    delete:
+      tags:
+        - Users
+      operationId: ResetUsersMFA
+      description: |
+        Reset a specific environment MFA factor for a user.
+
+        <div>
+          <code>delete:user_mfa</code>
+        </div>
+      summary: Reset specific environment MFA for a user
+      parameters:
+        - name: user_id
+          in: path
+          description: The identifier for the user
+          required: true
+          schema:
+            type: string
+            example: kp_c3143a4b50ad43c88e541d9077681782
+        - name: factor_id
+          in: path
+          description: The identifier for the MFA factor
+          required: true
+          schema:
+            type: string
+            example: mfa_0193278a00ac29b3f6d4e4d462d55c47
+      responses:
+        '200':
+          description: User's MFA successfully reset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/success_response'
+        '400':
+          $ref: '#/components/responses/bad_request'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '404':
+          $ref: '#/components/responses/not_found'
+        '429':
+          $ref: '#/components/responses/too_many_requests'
+      security:
+        - kindeBearerAuth: []
+  /api/v1/events/{event_id}:
+    servers: []
+    get:
+      tags:
+        - Webhooks
+      operationId: GetEvent
+      x-scope: read:events
+      description: |
+        Returns an event
+
+        <div>
+          <code>read:events</code>
+        </div>
+      summary: Get Event
+      parameters:
+        - name: event_id
+          in: path
+          description: The event id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Event successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_event_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_event_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/event_types:
+    servers: []
+    get:
+      tags:
+        - Webhooks
+      operationId: GetEventTypes
+      x-scope: read:event_types
+      description: |
+        Returns a list event type definitions
+
+        <div>
+          <code>read:event_types</code>
+        </div>
+      summary: List Event Types
+      responses:
+        '200':
+          description: Event types successfully retrieved.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_event_types_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_event_types_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/webhooks/{webhook_id}:
+    servers: []
+    delete:
+      tags:
+        - Webhooks
+      operationId: DeleteWebHook
+      description: |
+        Delete webhook
+
+        <div>
+          <code>delete:webhooks</code>
+        </div>
+      summary: Delete Webhook
+      parameters:
+        - name: webhook_id
+          in: path
+          description: The webhook id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: Webhook successfully deleted.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/delete_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/delete_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    patch:
+      tags:
+        - Webhooks
+      operationId: UpdateWebHook
+      description: |
+        Update a webhook
+
+        <div>
+          <code>update:webhooks</code>
+        </div>
+      summary: Update a Webhook
+      parameters:
+        - name: webhook_id
+          in: path
+          description: The webhook id.
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        description: Update webhook request specification.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event_types:
+                  description: Array of event type keys
+                  type: array
+                  items:
+                    type: string
+                  nullable: false
+                name:
+                  description: The webhook name
+                  type: string
+                  nullable: false
+                description:
+                  description: The webhook description
+                  type: string
+                  nullable: true
+      responses:
+        '200':
+          description: Webhook successfully updated.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/update_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+  /api/v1/webhooks:
+    servers: []
+    get:
+      tags:
+        - Webhooks
+      operationId: GetWebHooks
+      description: |
+        List webhooks
+
+        <div>
+          <code>read:webhooks</code>
+        </div>
+      summary: List Webhooks
+      responses:
+        '200':
+          description: Webhook list successfully returned.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/get_webhooks_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_webhooks_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+    post:
+      tags:
+        - Webhooks
+      operationId: CreateWebHook
+      description: |
+        Create a webhook
+
+        <div>
+          <code>create:webhooks</code>
+        </div>
+      summary: Create a Webhook
+      requestBody:
+        description: Webhook request specification.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                endpoint:
+                  description: The webhook endpoint url
+                  type: string
+                  nullable: false
+                event_types:
+                  description: Array of event type keys
+                  type: array
+                  items:
+                    type: string
+                  nullable: false
+                name:
+                  description: The webhook name
+                  type: string
+                  nullable: false
+                description:
+                  description: The webhook description
+                  type: string
+                  nullable: true
+              required:
+                - endpoint
+                - event_types
+                - name
+      responses:
+        '200':
+          description: Webhook successfully created.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/create_webhook_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_webhook_response'
+        '400':
+          description: Invalid request.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '403':
+          description: Invalid credentials.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/error_response'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '429':
+          description: Request was throttled.
+      security:
+        - kindeBearerAuth: []
+components:
+  parameters:
+    api_id:
+      in: path
+      name: api_id
+      description: The API's ID.
+      required: true
+      schema:
+        type: string
+        example: 7ccd126599aa422a771abcb341596881
+    application_id:
+      in: path
+      name: application_id
+      description: The application's ID / client ID.
+      required: true
+      schema:
+        type: string
+        example: 3b0b5c6c8fcc464fab397f4969b5f482
+    property_key:
+      in: path
+      name: property_key
+      description: The property's key.
+      required: true
+      schema:
+        type: string
+        example: kp_some_key
+    variable_id:
+      in: path
+      name: variable_id
+      description: The environment variable's ID.
+      required: true
+      schema:
+        type: string
+        example: env_var_0192b1941f125645fa15bf28a662a0b3
+  responses:
+    bad_request:
+      description: Invalid request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+    not_found:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/not_found_response'
+    forbidden:
+      description: Unauthorized - invalid credentials.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+    too_many_requests:
+      description: Too many requests. Request was throttled.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_response'
+  schemas:
+    success_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Success
+        code:
+          type: string
+          example: OK
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Error code.
+        message:
+          type: string
+          description: Error message.
+    error_response:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/error'
+    not_found_response:
+      type: object
+      properties:
+        errors:
+          type: object
+          properties:
+            code:
+              type: string
+              example: ROUTE_NOT_FOUND
+            message:
+              type: string
+              example: The requested API route does not exist
+    get_apis_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        next_token:
+          type: string
+          description: Pagination token.
+          example: Njo5Om1hvWVfYXNj
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                description: The unique ID for the API.
+                type: string
+                example: 7ccd126599aa422a771abcb341596881
+              name:
+                type: string
+                description: The API's name.
+                example: Example API
+              audience:
+                type: string
+                description: A unique identifier for the API - commonly the URL. This value will be used as the `audience` parameter in authorization claims.
+                example: https://api.example.com
+              is_management_api:
+                type: boolean
+                description: Whether or not it is the Kinde management API.
+                example: false
+              scopes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      example: api_scope_01939128c3d7193ae87c4755213c07c6
+                    key:
+                      type: string
+                      example: create:apis
+    create_apis_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Success
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: OK
+        api:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the API.
+              type: string
+              example: 7ccd126599aa422a771abcb341596881
+    create_api_scopes_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Success
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: OK
+        scope:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the API scope.
+              type: string
+              example: api_scope_0193ab57965aef77b2b687d0ef673713
+    get_environment_variables_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+        environment_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/environment_variable'
+    get_environment_variable_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        environment_variable:
+          $ref: '#/components/schemas/environment_variable'
+    create_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable created
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: VARIABLE_CREATED
+        environment_variable:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the environment variable.
+              type: string
+              example: env_var_0192b194f6156fb7452fe38cfb144958
+    update_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable updated
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: ENVIRONMENT_VARIABLE_UPDATED
+    delete_environment_variable_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: Environment variable deleted
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: ENVIRONMENT_VARIABLE_DELETED
+    get_business_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        business:
+          type: object
+          properties:
+            code:
+              type: string
+              description: The unique ID for the business.
+              example: bus_c69fb73b091
+            name:
+              type: string
+              description: Your business's name.
+              example: Tailsforce Ltd
+            phone:
+              type: string
+              description: Phone number associated with business.
+              example: 555-555-5555
+              nullable: true
+            email:
+              type: string
+              description: Email address associated with business.
+              example: sally@example.com
+              nullable: true
+            industry:
+              type: string
+              description: The industry your business is in.
+              example: Healthcare & Medical
+              nullable: true
+            timezone:
+              type: string
+              description: The timezone your business is in.
+              example: Los Angeles (Pacific Standard Time)
+              nullable: true
+            privacy_url:
+              type: string
+              description: Your Privacy policy URL.
+              example: https://example.com/privacy
+              nullable: true
+            terms_url:
+              type: string
+              description: Your Terms and Conditions URL.
+              example: https://example.com/terms
+              nullable: true
+            has_clickwrap:
+              type: boolean
+              description: Whether your business uses clickwrap agreements.
+              example: false
+            has_kinde_branding:
+              type: boolean
+              description: Whether your business shows Kinde branding.
+              example: true
+            created_on:
+              type: string
+              description: Date of business creation in ISO 8601 format.
+              example: '2021-01-01T00:00:00Z'
+    get_industries_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        industries:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                description: The unique key for the industry.
+                type: string
+                example: administration_office_support
+              name:
+                type: string
+                description: The display name for the industry.
+                example: Administration & Office Support
+    get_timezones_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        timezones:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                description: The unique key for the timezone.
+                type: string
+                example: london_greenwich_mean_time
+              name:
+                type: string
+                description: The display name for the timezone.
+                example: London (Greenwich Mean Time) [+01:00]
+    get_api_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: success_response
+        api:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Unique ID of the API.
+              example: 7ccd126599aa422a771abcb341596881
+            name:
+              type: string
+              description: The API's name.
+              example: Example API
+            audience:
+              type: string
+              description: A unique identifier for the API - commonly the URL. This value will be used as the `audience` parameter in authorization claims.
+              example: https://api.example.com
+            is_management_api:
+              type: boolean
+              description: Whether or not it is the Kinde management API.
+              example: false
+            scopes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: The ID of the scope.
+                    example: api_scope_01939222ef24200668b9f5829af001ce
+                  key:
+                    type: string
+                    description: The reference key for the scope.
+                    example: read:logs
+            applications:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: The Client ID of the application.
+                    example: 3b0b5c6c8fcc464fab397f4969b5f482
+                  name:
+                    type: string
+                    description: The application's name.
+                    example: My M2M app
+                  type:
+                    type: string
+                    description: The application's type.
+                    enum:
+                      - Machine to machine (M2M)
+                      - Back-end web
+                      - Front-end and mobile
+                      - Device and IoT
+                    example: Machine to machine (M2M)
+                  is_active:
+                    type: boolean
+                    description: Whether or not the application is authorized to access the API
+                    example: true
+                    nullable: true
+    get_api_scopes_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: success_response
+        scopes:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique ID of the API scope.
+                example: api_scope_01939128c3d7193ae87c4755213c07c6
+              key:
+                type: string
+                description: The scope's reference key.
+                example: read:logs
+              description:
+                type: string
+                description: Explanation of the scope purpose.
+                example: Read logs scope
+    get_api_scope_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: success_response
+        scope:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Unique ID of the API scope.
+              example: api_scope_01939128c3d7193ae87c4755213c07c6
+            key:
+              type: string
+              description: The scope's reference key.
+              example: read:logs
+            description:
+              type: string
+              description: Explanation of the scope purpose.
+              example: Read logs scope
+    authorize_app_api_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: API applications updated
+        code:
+          type: string
+          example: API_APPLICATIONS_UPDATED
+        applications_disconnected:
+          type: array
+          items:
+            type: string
+        applications_connected:
+          type: array
+          items:
+            type: string
+            example: d2db282d6214242b3b145c123f0c123
+    delete_api_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: API successfully deleted
+        code:
+          type: string
+          example: API_DELETED
+    user:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique ID of the user in Kinde.
+        provided_id:
+          type: string
+          description: External ID for user.
+        preferred_email:
+          type: string
+          description: Default email address of the user in Kinde.
+        phone:
+          type: string
+          description: User's primary phone number.
+        username:
+          type: string
+          description: Primary username of the user in Kinde.
+        last_name:
+          type: string
+          description: User's last name.
+        first_name:
+          type: string
+          description: User's first name.
+        is_suspended:
+          type: boolean
+          description: Whether the user is currently suspended or not.
+        picture:
+          type: string
+          description: User's profile picture URL.
+        total_sign_ins:
+          type: integer
+          description: Total number of user sign ins.
+          nullable: true
+        failed_sign_ins:
+          type: integer
+          description: Number of consecutive failed user sign ins.
+          nullable: true
+        last_signed_in:
+          type: string
+          description: Last sign in date in ISO 8601 format.
+          nullable: true
+        created_on:
+          type: string
+          description: Date of user creation in ISO 8601 format.
+          nullable: true
+        organizations:
+          type: array
+          description: Array of organizations a user belongs to.
+          items:
+            type: string
+        identities:
+          type: array
+          description: Array of identities belonging to the user.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              identity:
+                type: string
+        billing:
+          type: object
+          properties:
+            customer_id:
+              type: string
+    update_user_response:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique ID of the user in Kinde.
+        given_name:
+          type: string
+          description: User's first name.
+        family_name:
+          type: string
+          description: User's last name.
+        email:
+          type: string
+          description: User's preferred email.
+        is_suspended:
+          type: boolean
+          description: Whether the user is currently suspended or not.
+        is_password_reset_requested:
+          type: boolean
+          description: Whether a password reset has been requested.
+        picture:
+          type: string
+          description: User's profile picture URL.
+          nullable: true
+    users:
+      type: array
+      description: Array of users.
+      items:
+        $ref: '#/components/schemas/user'
+    users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique ID of the user in Kinde.
+              provided_id:
+                type: string
+                description: External ID for user.
+              email:
+                type: string
+                description: Default email address of the user in Kinde.
+              phone:
+                type: string
+                description: User's primary phone number.
+              username:
+                type: string
+                description: Primary username of the user in Kinde.
+              last_name:
+                type: string
+                description: User's last name.
+              first_name:
+                type: string
+                description: User's first name.
+              is_suspended:
+                type: boolean
+                description: Whether the user is currently suspended or not.
+              picture:
+                type: string
+                description: User's profile picture URL.
+              total_sign_ins:
+                type: integer
+                description: Total number of user sign ins.
+                nullable: true
+              failed_sign_ins:
+                type: integer
+                description: Number of consecutive failed user sign ins.
+                nullable: true
+              last_signed_in:
+                type: string
+                description: Last sign in date in ISO 8601 format.
+                nullable: true
+              created_on:
+                type: string
+                description: Date of user creation in ISO 8601 format.
+                nullable: true
+              last_organization_sign_ins:
+                type: array
+                description: Array of organization sign-in information for the user.
+                nullable: true
+                items:
+                  type: object
+                  properties:
+                    org_code:
+                      type: string
+                      description: The organization code.
+                      example: org_d2d85014942
+                    last_signed_in:
+                      type: string
+                      format: date-time
+                      description: The date and time the user last signed in to this organization in ISO 8601 format.
+                      example: '2026-01-28T14:26:02.448856+00:00'
+              organizations:
+                type: array
+                description: Array of organizations a user belongs to.
+                items:
+                  type: string
+              identities:
+                type: array
+                description: Array of identities belonging to the user.
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    identity:
+                      type: string
+              billing:
+                type: object
+                properties:
+                  customer_id:
+                    type: string
+                    description: The billing customer id.
+                    example: customer_1245adbc6789
+        next_token:
+          type: string
+          description: Pagination token.
+    search_users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique ID of the user in Kinde.
+                example: kp_0ba7c433e5d648cf992621ce99d42817
+              provided_id:
+                type: string
+                description: External ID for user.
+                nullable: true
+                example: U123456
+              email:
+                type: string
+                description: Default email address of the user in Kinde.
+                nullable: true
+                example: user@domain.com
+              username:
+                type: string
+                description: Primary username of the user in Kinde.
+                nullable: true
+                example: john.snow
+              last_name:
+                type: string
+                description: User's last name.
+                example: Snow
+              first_name:
+                type: string
+                description: User's first name.
+                example: John
+              is_suspended:
+                type: boolean
+                description: Whether the user is currently suspended or not.
+                example: true
+              picture:
+                type: string
+                description: User's profile picture URL.
+                example: https://example.com/john_snow.jpg
+                nullable: true
+              total_sign_ins:
+                type: integer
+                description: Total number of user sign ins.
+                nullable: true
+                example: 1
+              failed_sign_ins:
+                type: integer
+                description: Number of consecutive failed user sign ins.
+                nullable: true
+                example: 0
+              last_signed_in:
+                type: string
+                description: Last sign in date in ISO 8601 format.
+                nullable: true
+                example: '2025-02-12T18:02:23.614638+00:00'
+              created_on:
+                type: string
+                description: Date of user creation in ISO 8601 format.
+                nullable: true
+                example: '2025-02-12T18:02:23.614638+00:00'
+              organizations:
+                type: array
+                description: Array of organizations a user belongs to.
+                items:
+                  type: string
+              identities:
+                type: array
+                description: Array of identities belonging to the user.
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    identity:
+                      type: string
+              properties:
+                type: object
+                description: The user properties.
+                additionalProperties:
+                  type: string
+              api_scopes:
+                type: array
+                description: Array of api scopes belonging to the user.
+                items:
+                  type: object
+                  properties:
+                    org_code:
+                      type: string
+                    scope:
+                      type: string
+                    api_id:
+                      type: string
+    create_user_response:
+      type: object
+      properties:
+        id:
+          description: Unique ID of the user in Kinde.
+          type: string
+        created:
+          description: True if the user was successfully created.
+          type: boolean
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/user_identity'
+    create_organization_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        organization:
+          type: object
+          properties:
+            code:
+              description: The organization's unique code.
+              type: string
+              example: org_1ccfb819462
+            billing_customer_id:
+              description: The billing customer id if the organization was created with the is_create_billing_customer as true
+              type: string
+              example: customer_1245adbc6789
+    user_identity:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of identity object created.
+        result:
+          type: object
+          description: The result of the user creation operation.
+          properties:
+            created:
+              type: boolean
+              description: True if the user identity was successfully created.
+    create_property_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        property:
+          type: object
+          properties:
+            id:
+              description: The property's ID.
+              type: string
+    create_identity_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        identity:
+          type: object
+          properties:
+            id:
+              description: The identity's ID.
+              type: string
+            identity_id:
+              description: The identity's ID (returned when creating with existing enterprise identity).
+              type: string
+    get_identities_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/identity'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_user_sessions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          example: OK
+        message:
+          type: string
+          example: Success
+        has_more:
+          type: boolean
+          example: false
+        sessions:
+          type: array
+          items:
+            type: object
+            properties:
+              user_id:
+                description: The unique identifier of the user associated with the session.
+                type: string
+                example: kp_5fc30d0547734f30aca617450202169f
+              org_code:
+                description: The organization code associated with the session, if applicable.
+                type: string
+                nullable: true
+                example: org_1ccfb819462
+              client_id:
+                description: The client ID used to initiate the session.
+                type: string
+                example: 3b0b5c6c8fcc464fab397f4969b5f482
+              expires_on:
+                description: The timestamp indicating when the session will expire.
+                type: string
+                format: date-time
+                example: '2025-04-02T13:04:20.315701+11:00'
+              session_id:
+                description: The unique identifier of the session.
+                type: string
+                example: session_0xc75ec12fe8434ffc9d527794f00692e5
+              started_on:
+                description: The timestamp when the session was initiated.
+                type: string
+                format: date-time
+                example: '2025-04-01T13:04:20.315701+11:00'
+              updated_on:
+                description: The timestamp of the last update to the session.
+                type: string
+                format: date-time
+                example: '2025-04-01T13:04:20+11'
+              connection_id:
+                description: The identifier of the connection through which the session was established.
+                type: string
+                example: conn_75ab8ec0faae4f73bae9fc64daf120c9
+              last_ip_address:
+                description: The last known IP address of the user during this session.
+                type: string
+                example: 192.168.65.1
+              last_user_agent:
+                description: The last known user agent (browser or app) used during this session.
+                type: string
+                example: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36
+              initial_ip_address:
+                description: The IP address from which the session was initially started.
+                type: string
+                example: 192.168.65.1
+              initial_user_agent:
+                description: The user agent (browser or app) used when the session was first created.
+                type: string
+                example: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36
+    get_user_mfa_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        mfa:
+          type: object
+          properties:
+            id:
+              description: The MFA's identifier.
+              type: string
+              example: mfa_01933d1ca1f093e7fad48ebcdb65a871
+            type:
+              description: The type of MFA (e.g. email, SMS, authenticator app).
+              type: string
+              example: email
+            created_on:
+              description: The timestamp when the MFA was created.
+              type: string
+              format: date-time
+              example: '2024-11-18T13:31:46.795085+11:00'
+            name:
+              description: The identifier used for MFA (e.g. email address, phone number).
+              type: string
+              example: sally@gmail.com
+            is_verified:
+              description: Whether the MFA is verified or not.
+              type: boolean
+              example: true
+            usage_count:
+              description: The number of times MFA has been used.
+              type: integer
+              example: 2
+            last_used_on:
+              description: The timestamp when the MFA was last used.
+              type: string
+              format: date-time
+              example: '2024-11-18T13:32:07.22538+11:00'
+    get_properties_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_property_values_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/property_value'
+        next_token:
+          description: Pagination token.
+          type: string
+    create_category_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        category:
+          type: object
+          properties:
+            id:
+              description: The category's ID.
+              type: string
+    get_categories_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/category'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    get_event_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        event:
+          type: object
+          properties:
+            type:
+              type: string
+            source:
+              type: string
+            event_id:
+              type: string
+            timestamp:
+              type: integer
+              description: Timestamp in ISO 8601 format.
+            data:
+              type: object
+              description: Event specific data object.
+    get_event_types_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        event_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/event_type'
+    get_webhooks_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        webhooks:
+          type: array
+          items:
+            $ref: '#/components/schemas/webhook'
+    webhook:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        endpoint:
+          type: string
+        description:
+          type: string
+        event_types:
+          type: array
+          items:
+            type: string
+        created_on:
+          type: string
+          description: Created on date in ISO 8601 format.
+    create_webhook_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        webhook:
+          type: object
+          properties:
+            id:
+              type: string
+            endpoint:
+              type: string
+    update_webhook_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        webhook:
+          type: object
+          properties:
+            id:
+              type: string
+    create_connection_response:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        connection:
+          type: object
+          properties:
+            id:
+              description: The connection's ID.
+              type: string
+    get_connections_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        connections:
+          type: array
+          items:
+            $ref: '#/components/schemas/connection'
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+    delete_webhook_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+    event_type:
+      type: object
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+        name:
+          type: string
+        origin:
+          type: string
+        schema:
+          type: object
+    organization_item_schema:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The unique identifier for the organization.
+          example: org_1ccfb819462
+        name:
+          type: string
+          description: The organization's name.
+          example: Acme Corp
+        handle:
+          type: string
+          description: A unique handle for the organization - can be used for dynamic callback urls.
+          example: acme_corp
+          nullable: true
+        is_default:
+          type: boolean
+          description: Whether the organization is the default organization.
+          example: false
+        external_id:
+          type: string
+          description: The organization's external identifier - commonly used when migrating from or mapping to other systems.
+          example: some1234
+          nullable: true
+        is_auto_membership_enabled:
+          type: boolean
+          example: true
+          description: If users become members of this organization when the org code is supplied during authentication.
+    get_environment_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: success_response
+        environment:
+          type: object
+          properties:
+            code:
+              type: string
+              description: The unique identifier for the environment.
+              example: production
+            name:
+              type: string
+              description: The environment's name.
+              example: Production
+            hotjar_site_id:
+              type: string
+              description: Your HotJar site ID.
+              example: 404009
+              nullable: true
+            google_analytics_tag:
+              type: string
+              description: Your Google Analytics tag.
+              example: G-1234567
+              nullable: true
+            is_default:
+              type: boolean
+              description: Whether the environment is the default. Typically this is your production environment.
+              example: true
+            is_live:
+              type: boolean
+              description: Whether the environment is live.
+              example: true
+            kinde_domain:
+              type: string
+              description: Your domain on Kinde
+              example: example.kinde.com
+            custom_domain:
+              type: string
+              description: Your custom domain for the environment
+              nullable: true
+              example: app.example.com
+            logo:
+              type: string
+              nullable: true
+              description: The organization's logo URL.
+              example: https://yoursubdomain.kinde.com/logo?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+            logo_dark:
+              type: string
+              nullable: true
+              description: The organization's logo URL to be used for dark themes.
+              example: https://yoursubdomain.kinde.com/logo_dark?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+            favicon_svg:
+              type: string
+              nullable: true
+              description: The organization's SVG favicon URL. Optimal format for most browsers
+              example: https://yoursubdomain.kinde.com/favicon_svg?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+            favicon_fallback:
+              type: string
+              nullable: true
+              description: The favicon URL to be used as a fallback in browsers that don't support SVG, add a PNG
+              example: https://yoursubdomain.kinde.com/favicon_fallback?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+            link_color:
+              type: object
+              nullable: true
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            background_color:
+              nullable: true
+              type: object
+              properties:
+                raw:
+                  type: string
+                  example: '#ffffff'
+                hex:
+                  type: string
+                  example: '#ffffff'
+                hsl:
+                  type: string
+                  example: hsl(0, 0%, 100%)
+            button_color:
+              nullable: true
+              type: object
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            button_text_color:
+              nullable: true
+              type: object
+              properties:
+                raw:
+                  type: string
+                  example: '#ffffff'
+                hex:
+                  type: string
+                  example: '#ffffff'
+                hsl:
+                  type: string
+                  example: hsl(0, 0%, 100%)
+            link_color_dark:
+              type: object
+              nullable: true
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            background_color_dark:
+              type: object
+              nullable: true
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            button_text_color_dark:
+              type: object
+              nullable: true
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            button_color_dark:
+              type: object
+              nullable: true
+              properties:
+                raw:
+                  type: string
+                  example: '#0056F1'
+                hex:
+                  type: string
+                  example: '#0056F1'
+                hsl:
+                  type: string
+                  example: hsl(220, 100%, 50%)
+            button_border_radius:
+              type: integer
+              nullable: true
+              description: The border radius for buttons. Value is px, Kinde transforms to rem for rendering
+              example: 8
+            card_border_radius:
+              type: integer
+              nullable: true
+              description: The border radius for cards. Value is px, Kinde transforms to rem for rendering
+              example: 16
+            input_border_radius:
+              type: integer
+              nullable: true
+              description: The border radius for inputs. Value is px, Kinde transforms to rem for rendering
+              example: 4
+            theme_code:
+              type: string
+              description: Whether the environment is forced into light mode, dark mode or user preference
+              enum:
+                - light
+                - dark
+                - user_preference
+            color_scheme:
+              type: string
+              description: The color scheme for the environment used for meta tags based on the theme code
+              enum:
+                - light
+                - dark
+                - light dark
+            created_on:
+              type: string
+              description: Date of environment creation in ISO 8601 format.
+              example: '2021-01-01T00:00:00Z'
+    get_organization_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The unique identifier for the organization.
+          example: org_1ccfb819462
+        name:
+          type: string
+          description: The organization's name.
+          example: Acme Corp
+        handle:
+          type: string
+          description: A unique handle for the organization - can be used for dynamic callback urls.
+          example: acme_corp
+          nullable: true
+        is_default:
+          type: boolean
+          description: Whether the organization is the default organization.
+          example: false
+        external_id:
+          type: string
+          description: The organization's external identifier - commonly used when migrating from or mapping to other systems.
+          example: some1234
+          nullable: true
+        is_auto_membership_enabled:
+          type: boolean
+          example: true
+          description: If users become members of this organization when the org code is supplied during authentication.
+        logo:
+          type: string
+          nullable: true
+          description: The organization's logo URL.
+          example: https://yoursubdomain.kinde.com/logo?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+        logo_dark:
+          type: string
+          nullable: true
+          description: The organization's logo URL to be used for dark themes.
+          example: https://yoursubdomain.kinde.com/logo_dark?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+        favicon_svg:
+          type: string
+          nullable: true
+          description: The organization's SVG favicon URL. Optimal format for most browsers
+          example: https://yoursubdomain.kinde.com/favicon_svg?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+        favicon_fallback:
+          type: string
+          nullable: true
+          description: The favicon URL to be used as a fallback in browsers that don't support SVG, add a PNG
+          example: https://yoursubdomain.kinde.com/favicon_fallback?org_code=org_1ccfb819462&cache=311308b8ad3544bf8e572979f0e5748d
+        allowed_domains:
+          type: array
+          description: Domains allowed for self-sign up to this environment.  Empty array means no restrictions.
+          example:
+            - https://acme.kinde.com
+            - https://acme.com
+          items:
+            type: string
+        link_color:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        background_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#ffffff'
+            hex:
+              type: string
+              example: '#ffffff'
+            hsl:
+              type: string
+              example: hsl(0, 0%, 100%)
+        button_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_text_color:
+          nullable: true
+          type: object
+          properties:
+            raw:
+              type: string
+              example: '#ffffff'
+            hex:
+              type: string
+              example: '#ffffff'
+            hsl:
+              type: string
+              example: hsl(0, 0%, 100%)
+        link_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        background_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_text_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_color_dark:
+          type: object
+          nullable: true
+          properties:
+            raw:
+              type: string
+              example: '#0056F1'
+            hex:
+              type: string
+              example: '#0056F1'
+            hsl:
+              type: string
+              example: hsl(220, 100%, 50%)
+        button_border_radius:
+          type: integer
+          nullable: true
+          description: The border radius for buttons. Value is px, Kinde transforms to rem for rendering
+          example: 8
+        card_border_radius:
+          type: integer
+          nullable: true
+          description: The border radius for cards. Value is px, Kinde transforms to rem for rendering
+          example: 16
+        input_border_radius:
+          type: integer
+          nullable: true
+          description: The border radius for inputs. Value is px, Kinde transforms to rem for rendering
+          example: 4
+        theme_code:
+          type: string
+          description: Whether the environment is forced into light mode, dark mode or user preference
+          enum:
+            - light
+            - dark
+            - user_preference
+        color_scheme:
+          type: string
+          description: The color scheme for the environment used for meta tags based on the theme code
+          enum:
+            - light
+            - dark
+            - light dark
+        created_on:
+          type: string
+          description: Date of organization creation in ISO 8601 format.
+          example: '2021-01-01T00:00:00Z'
+        is_allow_registrations:
+          nullable: true
+          type: boolean
+          example: true
+          deprecated: true
+          description: Deprecated - Use 'is_auto_membership_enabled' instead
+        sender_name:
+          nullable: true
+          type: string
+          example: Acme Corp
+          description: The name of the organization that will be used in emails
+        sender_email:
+          nullable: true
+          type: string
+          example: hello@acmecorp.com
+          description: The email address that will be used in emails. Requires custom SMTP to be set up.
+        billing:
+          type: object
+          description: The billing information if the organization is a billing customer.
+          properties:
+            billing_customer_id:
+              type: string
+            agreements:
+              type: array
+              description: The billing agreements the billing customer is currently subscribed to
+              items:
+                type: object
+                properties:
+                  plan_code:
+                    type: string
+                    example: pro
+                    description: The code of the plan from which this agreement is taken from
+                  agreement_id:
+                    type: string
+                    example: agreement_a1234b
+                    description: The id of the billing agreement in Kinde
+    organization_user:
+      type: object
+      properties:
+        id:
+          type: string
+          example: kp:97c2ba24217d48e3b96a799b76cf2c74
+          description: The unique ID for the user.
+          nullable: true
+        email:
+          type: string
+          example: john.snow@example.com
+          description: The user's email address.
+          nullable: true
+        full_name:
+          type: string
+          example: John Snow
+          description: The user's full name.
+        last_name:
+          type: string
+          example: Snow
+          description: The user's last name.
+          nullable: true
+        first_name:
+          type: string
+          example: John
+          description: The user's first name.
+          nullable: true
+        picture:
+          type: string
+          example: https://example.com/john_snow.jpg
+          description: The user's profile picture URL.
+          nullable: true
+        joined_on:
+          type: string
+          example: '2021-01-01T00:00:00Z'
+          description: The date the user joined the organization.
+        last_accessed_on:
+          type: string
+          example: '2022-01-01T00:00:00Z'
+          description: The date the user last accessed the organization.
+          nullable: true
+        is_suspended:
+          type: boolean
+          description: Whether the user is currently suspended or not.
+          example: false
+        roles:
+          type: array
+          description: The roles the user has in the organization.
+          items:
+            type: string
+            example: admin
+            description: The role's key.
+    category:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    connection:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        connection:
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            display_name:
+              type: string
+            strategy:
+              type: string
+    environment_variable:
+      type: object
+      properties:
+        id:
+          description: The unique ID for the environment variable.
+          type: string
+          example: env_var_0192b1941f125645fa15bf28a662a0b3
+        key:
+          type: string
+          description: The name of the environment variable.
+          example: MY_API_KEY
+        value:
+          type: string
+          description: The value of the environment variable.
+          example: some-secret
+          nullable: true
+        is_secret:
+          type: boolean
+          description: Whether the environment variable is sensitive.
+          example: false
+        created_on:
+          type: string
+          description: The date the environment variable was created.
+          example: '2021-01-01T00:00:00Z'
+    identity:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique ID for the identity
+          example: identity_019617f0cd72460a42192cf37b41084f
+        type:
+          type: string
+          description: The type of identity
+          example: email
+        is_confirmed:
+          type: boolean
+          description: Whether the identity is confirmed
+          example: true
+        created_on:
+          type: string
+          description: Date of user creation in ISO 8601 format
+          example: '2025-01-01T00:00:00Z'
+        last_login_on:
+          type: string
+          description: Date of last login in ISO 8601 format
+          example: '2025-01-05T00:00:00Z'
+        total_logins:
+          type: integer
+          example: 20
+        name:
+          type: string
+          description: The value of the identity
+          example: sally@example.com
+        email:
+          type: string
+          description: The associated email of the identity
+          example: sally@example.com
+        is_primary:
+          type: boolean
+          description: Whether the identity is the primary identity for the user
+          nullable: true
+          example: true
+    property:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        is_private:
+          type: boolean
+        description:
+          type: string
+        is_kinde_property:
+          type: boolean
+    property_value:
+      type: object
+      properties:
+        id:
+          type: string
+          example: prop_0192b7e8b4f8ca08110d2b22059662a8
+        name:
+          type: string
+          example: Town
+        description:
+          type: string
+          example: Where the entity is located
+          nullable: true
+        key:
+          type: string
+          example: kp_town
+        value:
+          type: string
+          example: West-side Staines massive
+          nullable: true
+    role:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+    subscribers_subscriber:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        full_name:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+    subscriber:
+      type: object
+      properties:
+        id:
+          type: string
+        preferred_email:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+    organization_user_role:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+    organization_user_role_permissions:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          type: string
+        permissions:
+          type: object
+          properties:
+            key:
+              type: string
+    organization_user_permission:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        roles:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              key:
+                type: string
+    organization_users:
+      type: array
+      items:
+        $ref: '#/components/schemas/organization_user'
+    get_subscriber_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        subscribers:
+          type: array
+          items:
+            $ref: '#/components/schemas/subscriber'
+    get_subscribers_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        subscribers:
+          type: array
+          items:
+            $ref: '#/components/schemas/subscribers_subscriber'
+        next_token:
+          description: Pagination token.
+          type: string
+    get_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/roles'
+        next_token:
+          description: Pagination token.
+          type: string
+    get_role_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        role:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The role's ID.
+              example: 01929904-316d-bb2c-069f-99dfea4ac394
+            key:
+              type: string
+              description: The role identifier to use in code.
+              example: admin
+            name:
+              type: string
+              description: The role's name.
+              example: Administrator
+            description:
+              type: string
+              description: The role's description.
+              example: Full access to all resources.
+            is_default_role:
+              type: boolean
+              description: Whether the role is the default role.
+              example: false
+    create_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        role:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The role's ID.
+    add_role_scope_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: ROLE_SCOPE_ADDED
+        message:
+          type: string
+          description: Response message.
+          example: Scope added to role
+    delete_role_scope_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: SCOPE_DELETED
+        message:
+          type: string
+          description: Response message.
+          example: Scope deleted from role
+    get_organizations_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_item_schema'
+        next_token:
+          description: Pagination token.
+          type: string
+          example: Mjo5Om1hbWVfYZNj
+    get_organization_users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        organization_users:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user'
+        next_token:
+          type: string
+          description: Pagination token.
+    get_organizations_user_roles_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user_role'
+        next_token:
+          type: string
+          description: Pagination token.
+    get_organizations_user_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/organization_user_permission'
+    get_organization_feature_flags_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        feature_flags:
+          type: object
+          description: The environment's feature flag settings.
+          additionalProperties:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - str
+                  - int
+                  - bool
+              value:
+                type: string
+    get_environment_feature_flags_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        feature_flags:
+          type: object
+          description: The environment's feature flag settings.
+          additionalProperties:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - str
+                  - int
+                  - bool
+              value:
+                type: string
+        next_token:
+          type: string
+          description: Pagination token.
+    add_organization_users_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        users_added:
+          type: array
+          items:
+            type: string
+    update_role_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        permissions_added:
+          type: array
+          items:
+            type: string
+        permissions_removed:
+          type: array
+          items:
+            type: string
+    update_organization_users_response:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Success
+        code:
+          type: string
+          example: OK
+        users_added:
+          type: array
+          items:
+            type: string
+            example: kp_057ee6debc624c70947b6ba512908c35
+        users_updated:
+          type: array
+          items:
+            type: string
+            example: kp_057ee6debc624c70947b6ba512908c35
+        users_removed:
+          type: array
+          items:
+            type: string
+            example: kp_057ee6debc624c70947b6ba512908c35
+    connected_apps_auth_url:
+      type: object
+      properties:
+        url:
+          type: string
+          description: A URL that is used to authenticate an end-user against a connected app.
+        session_id:
+          type: string
+          description: A unique identifier for the login session.
+    create_subscriber_success_response:
+      type: object
+      properties:
+        subscriber:
+          type: object
+          properties:
+            subscriber_id:
+              type: string
+              description: A unique identifier for the subscriber.
+    connected_apps_access_token:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: The access token to access a third-party provider.
+        access_token_expiry:
+          type: string
+          description: The date and time that the access token expires.
+    api_result:
+      type: object
+      properties:
+        result:
+          type: string
+          description: The result of the api operation.
+    create_application_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        application:
+          type: object
+          properties:
+            id:
+              description: The application's identifier.
+              type: string
+              example: 3b0b5c6c8fcc464fab397f4969b5f482
+            client_id:
+              description: The application's client ID.
+              type: string
+              example: 3b0b5c6c8fcc464fab397f4969b5f482
+            client_secret:
+              description: The application's client secret.
+              type: string
+              example: sUJSHI3ZQEVTJkx6hOxdOSHaLsZkCBRFLzTNOI791rX8mDjgt7LC
+    get_application_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        application:
+          type: object
+          properties:
+            id:
+              description: The application's identifier.
+              type: string
+              example: 3b0b5c6c8fcc464fab397f4969b5f482
+            name:
+              description: The application's name.
+              type: string
+              example: My React app
+            type:
+              description: The application's type.
+              type: string
+              enum:
+                - m2m
+                - reg
+                - spa
+            client_id:
+              description: The application's client ID.
+              type: string
+              example: 3b0b5c6c8fcc464fab397f4969b5f482
+            client_secret:
+              description: The application's client secret.
+              type: string
+              example: sUJSHI3ZQEVTJkx6hOxdOSHaLsZkCBRFLzTNOI791rX8mDjgt7LC
+            login_uri:
+              description: The default login route for resolving session issues.
+              type: string
+              example: https://yourapp.com/api/auth/login
+            homepage_uri:
+              description: The homepage link to your application.
+              type: string
+              example: https://yourapp.com
+            has_cancel_button:
+              description: Whether the application has a cancel button to allow users to exit the auth flow [Beta].
+              type: boolean
+              example: false
+    applications:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+    get_applications_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        applications:
+          type: array
+          items:
+            $ref: '#/components/schemas/applications'
+        next_token:
+          description: Pagination token.
+          type: string
+    redirect_callback_urls:
+      type: object
+      properties:
+        redirect_urls:
+          type: array
+          description: An application's redirect URLs.
+          items:
+            type: string
+    get_redirect_callback_urls_response:
+      type: object
+      properties:
+        redirect_urls:
+          description: An application's redirect callback URLs.
+          type: array
+          items:
+            $ref: '#/components/schemas/redirect_callback_urls'
+    logout_redirect_urls:
+      type: object
+      properties:
+        logout_urls:
+          type: array
+          description: An application's logout URLs.
+          items:
+            type: string
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+    get_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/permissions'
+        next_token:
+          type: string
+          description: Pagination token.
+    permissions:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The permission's ID.
+        key:
+          type: string
+          description: The permission identifier to use in code.
+        name:
+          type: string
+          description: The permission's name.
+        description:
+          type: string
+          description: The permission's description.
+    scopes:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Scope ID.
+          example: api_scope_019541f3fa0c874fc47b3ae73585b21c
+        key:
+          type: string
+          description: Scope key.
+          example: create:users
+        description:
+          type: string
+          description: Description of scope.
+          example: Create users
+        api_id:
+          type: string
+          description: API ID.
+          example: 3635b4431f174de6b789c67481bd0c7a
+    roles:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The role's ID.
+        key:
+          type: string
+          description: The role identifier to use in code.
+        name:
+          type: string
+          description: The role's name.
+        description:
+          type: string
+          description: The role's description.
+          nullable: true
+        is_default_role:
+          type: boolean
+          description: Whether the role is the default role.
+    role_permissions_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+        message:
+          type: string
+          description: Response message.
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/permissions'
+        next_token:
+          type: string
+          description: Pagination token.
+    role_scopes_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/scopes'
+    read_logo_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        logos:
+          type: array
+          description: A list of logos.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The type of logo (light or dark).
+                example: light
+              file_name:
+                type: string
+                description: The name of the logo file.
+                example: kinde_light.jpeg
+              path:
+                type: string
+                description: The relative path to the logo file.
+                example: /logo?p_org_code=org_1767f11ce62
+        message:
+          type: string
+          description: Response message.
+          example: Success
+    read_env_logo_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        logos:
+          type: array
+          description: A list of logos.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The type of logo (light or dark).
+                example: light
+              file_name:
+                type: string
+                description: The name of the logo file.
+                example: kinde_light.jpeg
+        message:
+          type: string
+          description: Response message.
+          example: Success
+    get_billing_entitlements_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+        entitlements:
+          type: array
+          description: A list of entitlements
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The friendly id of an entitlement
+                example: entitlement_0195ac80a14e8d71f42b98e75d3c61ad
+              fixed_charge:
+                type: integer
+                description: The price charged if this is an entitlement for a fixed charged
+                example: 35
+              price_name:
+                type: string
+                description: The name of the price associated with the entitlement
+                example: Pro gym
+              unit_amount:
+                type: integer
+                description: The price charged for this entitlement in cents
+              feature_code:
+                type: string
+                description: The feature code of the feature corresponding to this entitlement
+                example: CcdkvEXpbg6UY
+              feature_name:
+                type: string
+                description: The feature name of the feature corresponding to this entitlement
+                example: Pro Gym
+              entitlement_limit_max:
+                type: integer
+                description: The maximum number of units of the feature the customer is entitled to
+              entitlement_limit_min:
+                type: integer
+                description: The minimum number of units of the feature the customer is entitled to
+        plans:
+          type: array
+          description: A list of plans.
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+                description: The plan code the billing customer is subscribed to
+              subscribed_on:
+                type: string
+                format: date-time
+                example: '2024-11-18T13:32:03+11'
+    get_billing_agreements_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+        agreements:
+          type: array
+          description: A list of billing agreements
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The friendly id of an agreement
+                example: agreement_0195ac80a14c2ca2cec97d026d864de0
+              plan_code:
+                type: string
+                description: The plan code the billing customer is subscribed to
+              expires_on:
+                type: string
+                format: date-time
+                description: The date the agreement expired (and was no longer active)
+                example: '2024-11-18T13:32:03+11'
+              billing_group_id:
+                type: string
+                description: The friendly id of the billing group this agreement's plan is part of
+                example: sbg_0195abf6773fdae18d5da72281a3fde2
+              entitlements:
+                type: array
+                description: A list of billing entitlements that is part of this agreement
+                items:
+                  type: object
+                  properties:
+                    feature_code:
+                      type: string
+                      description: The feature code of the feature corresponding to this entitlement
+                      example: CcdkvEXpbg6UY
+                    entitlement_id:
+                      type: string
+                      description: The friendly id of an entitlement
+                      example: entitlement_0195ac80a14e8d71f42b98e75d3c61ad
+    create_meter_usage_record_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        code:
+          type: string
+          description: Response code.
+          example: OK
+    get_api_keys_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        has_more:
+          description: Whether more records exist.
+          type: boolean
+        api_keys:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                description: The unique ID for the API key.
+                type: string
+                example: api_key_0195ac80a14e8d71f42b98e75d3c61ad
+              name:
+                type: string
+                description: The API key's name.
+                example: My API Key
+              type:
+                type: string
+                description: The type of API key.
+                example: organization
+              status:
+                type: string
+                description: The status of the API key.
+                example: active
+              key_prefix:
+                type: string
+                description: The first 6 characters of the API key for identification.
+                example: kinde_
+              key_suffix:
+                type: string
+                description: The last 4 characters of the API key for identification.
+                example: abcd
+                nullable: true
+              created_on:
+                type: string
+                format: date-time
+                description: When the API key was created.
+                example: '2024-11-18T13:32:03+11'
+              last_verified_on:
+                type: string
+                format: date-time
+                description: When the API key was last verified.
+                example: '2024-11-18T13:32:03+11'
+                nullable: true
+              last_verified_ip:
+                type: string
+                description: The IP address from which the API key was last verified.
+                example: 192.168.1.1
+                nullable: true
+              created_by:
+                type: string
+                description: The name of the user who created the API key.
+                example: John Doe
+                nullable: true
+              api_ids:
+                type: array
+                description: Array of API IDs associated with this key.
+                items:
+                  type: string
+                example:
+                  - api_123
+                  - api_456
+              scopes:
+                type: array
+                description: Array of scopes associated with this key.
+                items:
+                  type: string
+                example:
+                  - read:users
+                  - write:users
+    rotate_api_key_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: API_KEY_ROTATED
+        message:
+          type: string
+          description: Response message.
+          example: API key rotated successfully
+        api_key:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The unique ID for the API key.
+              example: api_key_0195ac80a14e8d71f42b98e75d3c61ad
+            key:
+              type: string
+              description: The new API key value (only shown once).
+              example: k_live_1234567890abcdef1234567890abcdef
+    create_api_key_response:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A Kinde generated message.
+          example: API key created
+        code:
+          type: string
+          description: A Kinde generated status code.
+          example: API_KEY_CREATED
+        api_key:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the API key.
+              type: string
+              example: api_key_0195ac80a14e8d71f42b98e75d3c61ad
+            key:
+              description: The API key value (only shown once on creation).
+              type: string
+              example: k_live_1234567890abcdef
+    verify_api_key_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: API_KEY_VERIFIED
+        message:
+          type: string
+          description: Response message.
+          example: API key verified
+        is_valid:
+          type: boolean
+          description: Whether the API key is valid.
+          example: true
+        key_id:
+          type: string
+          description: The unique ID for the API key.
+          example: api_key_0195ac80a14e8d71f42b98e75d3c61ad
+        status:
+          type: string
+          description: The status of the API key.
+          example: active
+        scopes:
+          type: array
+          description: Array of scopes associated with this key.
+          items:
+            type: string
+          example:
+            - read:users
+            - write:users
+        org_code:
+          type: string
+          description: The organization code associated with this key.
+          example: org_123
+          nullable: true
+        user_id:
+          type: string
+          description: The user ID associated with this key.
+          example: user_456
+          nullable: true
+        last_verified_on:
+          type: string
+          format: date-time
+          description: When the API key was last verified.
+          example: '2024-11-18T13:32:03+11'
+          nullable: true
+        verification_count:
+          type: integer
+          description: Number of times this API key has been verified.
+          example: 42
+    get_api_key_response:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Response code.
+          example: OK
+        message:
+          type: string
+          description: Response message.
+          example: Success
+        api_key:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the API key.
+              type: string
+              example: api_key_0195ac80a14e8d71f42b98e75d3c61ad
+            name:
+              type: string
+              description: The API key's name.
+              example: My API Key
+            type:
+              type: string
+              description: The type of API key.
+              example: organization
+            status:
+              type: string
+              description: The status of the API key.
+              example: active
+            key_prefix:
+              type: string
+              description: The first 6 characters of the API key for identification.
+              example: k_live
+            key_suffix:
+              type: string
+              description: The last 4 characters of the API key for identification.
+              example: abcd
+              nullable: true
+            created_on:
+              type: string
+              format: date-time
+              description: When the API key was created.
+              example: '2024-11-18T13:32:03+11'
+            last_verified_on:
+              type: string
+              format: date-time
+              description: When the API key was last verified.
+              example: '2024-11-18T13:32:03+11'
+              nullable: true
+            last_verified_ip:
+              type: string
+              description: The IP address from which the API key was last verified.
+              example: 192.168.1.1
+              nullable: true
+            created_by:
+              type: string
+              description: The name of the user who created the API key.
+              example: John Doe
+              nullable: true
+            api_ids:
+              type: array
+              description: Array of API IDs associated with this key.
+              items:
+                type: string
+              example:
+                - api_123
+                - api_456
+            scopes:
+              type: array
+              description: Array of scopes associated with this key.
+              items:
+                type: string
+              example:
+                - read:users
+                - write:users
+            verification_count:
+              type: integer
+              description: Number of times this API key has been verified.
+              example: 42
+              nullable: true
+            organization_id:
+              type: string
+              description: The organization code associated with this key.
+              example: org_123
+              nullable: true
+            user_id:
+              type: string
+              description: The user ID associated with this key.
+              example: user_456
+              nullable: true
+  securitySchemes:
+    kindeBearerAuth:
+      description: |
+        Requires an access token obtained using the client_credentials flow.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
CreateUserIdentity response decodes identity_id from API

When creating an identity with an existing enterprise identity, the Kinde API returns identity_id instead of id. Add local OpenAPI spec with identity_id and regenerate SDK so the decoder accepts both; add EffectiveIdentityID() helper.

- Add spec/kinde-management-api-spec.yaml (from api-spec.kinde.com) with identity_id on create_identity_response.identity
- Update generate.go to use local spec
- Regenerate management_api (ogen) so CreateIdentityResponseIdentity has ID and IdentityID; decoder handles both JSON keys
- Add create_identity_response_helpers.go with EffectiveIdentityID()
- Add create_identity_response_test.go for id and identity_id decode paths

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
